### PR TITLE
Documentar soporte multi-municipio y retención temporal

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,14 @@
 En la Fase 0 no se declaran modelos concretos. Aquí se ubicarán las clases
 SQLAlchemy que representarán tablas como `alpr_readings`, `messages_queue`,
 `cameras`, `certificates` y `endpoints`.
+
+Modelos previstos (no implementados en Fase 0):
+- Municipality
+- Certificate
+- Endpoint
+- Camera
+- AlprReading
+- MessageQueue
 """
 
 # Los modelos se añadirán en fases posteriores cuando se diseñe el esquema SQL

--- a/docs/01-requisitos.md
+++ b/docs/01-requisitos.md
@@ -9,6 +9,13 @@
 - Firma de las peticiones SOAP con certificados PFX, seleccionados según la
   cámara/municipio.
 - Soporte para múltiples cámaras y certificados independientes.
+- El sistema debe ser multi-municipio: cada cámara se asocia a un municipio y
+  cada municipio puede tener su certificado PFX (y configuración de endpoint)
+  para Mossos, permitiendo compartir certificado entre varias cámaras a través
+  de su municipio.
+- Cada lectura ALPR se vincula a una cámara y, por extensión, al municipio y
+  certificado que se deben usar en el envío a Mossos en el momento de construir
+  la petición.
 - Registro de logs y estados de cada lectura (`PENDING`, `SENT`, `FAILED`, etc.).
 
 ## Requisitos no funcionales
@@ -22,3 +29,12 @@
   recibidas, encoladas, enviadas, fallidas).
 - Despliegue: orientado a VPS Ubuntu 22.04, con servicios gestionados por
   systemd o contenedores simples.
+
+### Retención y eliminación de datos
+- Las lecturas (matrículas, metadatos, XML e imágenes) se guardarán solo el
+  tiempo estrictamente necesario para completar el envío al endpoint de Mossos.
+- Tras un envío exitoso, el sistema eliminará la lectura, sus fotos y las
+  entradas de cola asociadas.
+- Opcionalmente se podrá conservar un registro de auditoría sin datos
+  personales (sin matrícula ni imagen), con información agregada como cámara,
+  municipio, fecha y resultado.

--- a/docs/02-arquitectura.md
+++ b/docs/02-arquitectura.md
@@ -4,16 +4,27 @@
 - **Ingest Service**: escucha tráfico Tattile (TCP/UDP), parsea el XML recibido y
   encola la lectura normalizada en la base de datos.
 - **Sender Worker**: consume la cola de mensajes pendientes, determina el
-  certificado y endpoint apropiado y envía la lectura mediante SOAP a Mossos.
+  certificado y endpoint apropiado resolviendo cámara → municipio → certificado
+  (y endpoint) y envía la lectura mediante SOAP a Mossos.
 - **Admin API (FastAPI)**: endpoints mínimos para administración (gestión de
   cámaras, certificados y consulta de estados) y métricas básicas.
-- **Base de datos PostgreSQL**: almacena cámaras, certificados, endpoints,
-  lecturas normalizadas y la cola de mensajes.
+- **Base de datos PostgreSQL**: almacena cámaras, municipios, certificados,
+  endpoints, lecturas normalizadas y la cola de mensajes.
 
 ## Flujo general
-- Tattile (XML) → Ingest → DB (cola de mensajes) → Sender Worker → Mossos.
+- Tattile (XML) → Ingest → DB (`alpr_readings` + `messages_queue`) → Sender
+  Worker → resolución cámara → municipio → certificado + endpoint → Mossos →
+  borrado de `alpr_readings`/`messages_queue` e imágenes en éxito.
 - En caso de fallo de envío, el mensaje permanece en cola y se reintenta con
   políticas configurables.
+
+### Sender Worker
+- Para cada mensaje en cola, obtiene la lectura y la cámara asociada.
+- A través de la cámara resuelve el municipio y, con él, el certificado y el
+  endpoint (o el endpoint específico de la cámara si lo hay).
+- Con estos datos firma y envía la petición SOAP a Mossos.
+- Si el envío se confirma, elimina el mensaje, la lectura y cualquier fichero de
+  imagen asociado, dejando opcionalmente un log de auditoría sin matrícula.
 
 ## Consideraciones de despliegue
 - Primera iteración orientada a servicios Python gestionados con systemd en VPS
@@ -21,3 +32,9 @@
 - Alternativamente se podrán ejecutar mediante Docker usando `docker-compose`
   para aislar base de datos y API.
 - No se prevé orquestación compleja (Kubernetes) en etapas tempranas.
+
+### Seguridad y privacidad
+- Seguridad: proteger certificados, credenciales y accesos; uso de HTTPS y
+  cifrado en reposo cuando aplique. La política de retención y eliminación
+  temporal de datos se detalla en `docs/01-requisitos.md` y guía las purgas
+  tras envíos exitosos.

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -1,25 +1,50 @@
 # Esquema de base de datos conceptual
 
+## Tabla `municipalities`
+- `id` (uuid): identificador único.
+- `name` (texto): nombre del municipio/ayuntamiento/instalación.
+- `code` (texto, opcional): código de referencia externa.
+- `certificate_id` (uuid, fk): referencia a `certificates` asociada al municipio.
+- `endpoint_id` (uuid, fk opcional): destino preferente; si no está, se usa
+  un endpoint por defecto.
+- `active` (booleano): indica si el municipio está habilitado.
+- Permite agrupar cámaras bajo un mismo certificado/endpoint sin duplicar
+  configuración.
+
 ## Tabla `certificates`
 - `id` (uuid): identificador único.
 - `name` (texto): nombre descriptivo del certificado.
-- `pfx_path` (texto): ruta al archivo .pfx en el servidor (fuera del repo).
+- `type` (enum): PFX/PEM u otro formato soportado.
+- `path` (texto): ruta al archivo de certificado en el servidor (fuera del
+  repositorio).
 - `password_hint` (texto, opcional): pista de contraseña sin exponer el valor.
-- `expires_at` (timestamp, opcional): fecha de caducidad conocida.
+- `valid_from` / `valid_to` (timestamp, opcional): ventana de validez conocida.
+- `active` (booleano): indica si se debe utilizar.
+- Puede ser reutilizado por varios municipios y, por extensión, por las cámaras
+  de dichos municipios.
 
 ## Tabla `endpoints`
 - `id` (uuid): identificador único.
 - `name` (texto): nombre descriptivo (ej. "Mossos Producción").
 - `url` (texto): endpoint SOAP.
+- `timeout_ms` (entero): timeout de petición en milisegundos.
+- `retry_max` (entero): número máximo de reintentos.
+- `retry_backoff_ms` (entero): backoff entre reintentos.
 - `soap_action` (texto, opcional): acción SOAP si aplica.
+- Normalmente apuntará a Mossos, pero el diseño permite otros destinos.
 
 ## Tabla `cameras`
 - `id` (uuid): identificador único.
-- `serial_number` (texto): `DEVICE_SN` de la cámara Tattile.
-- `code` (texto): código interno (ej. `CodigoLector` en legacy).
+- `serial_number` (texto, único): `DEVICE_SN` de la cámara Tattile.
+- `codigo_lector` (texto): código interno (ej. `CodigoLector` en legacy).
 - `description` (texto, opcional): detalle de ubicación.
-- `certificate_id` (uuid, fk): referencia a `certificates`.
-- `endpoint_id` (uuid, fk): referencia a `endpoints`.
+- `municipality_id` (uuid, fk): referencia a `municipalities` para resolver
+  certificado y endpoint.
+- `endpoint_id` (uuid, fk opcional): override de endpoint si la cámara tiene un
+  destino distinto al de su municipio.
+- `active` (booleano): indica si la cámara está habilitada.
+- Hereda certificado/endpoint a través del municipio, permitiendo compartir
+  configuración.
 
 ## Tabla `alpr_readings`
 - `id` (uuid): identificador único.
@@ -31,7 +56,12 @@
 - `bbox_min_x`, `bbox_min_y`, `bbox_max_x`, `bbox_max_y`, `char_height` (numéricos).
 - `has_image_ocr` (booleano), `has_image_ctx` (booleano).
 - `raw_xml` (texto largo o XML).
+- `camera_id` (uuid, fk): referencia a `cameras` para conocer municipio y
+  certificados asociados.
 - Índices sugeridos: por `plate`, por `timestamp_utc`, por `device_sn`.
+- Tabla de trabajo temporal: almacena lecturas mientras estén pendientes de
+  envío o en reintento. Tras envío exitoso se eliminan los registros y, si
+  aplica, las imágenes asociadas en disco/almacenamiento externo.
 
 ## Tabla `messages_queue`
 - `id` (uuid): identificador único.
@@ -41,10 +71,23 @@
 - `last_error` (texto opcional): mensaje de error del último intento.
 - `sent_at` (timestamp opcional): última fecha de envío exitoso.
 - `created_at` (timestamp): fecha de encolado.
+- Tabla de trabajo temporal: gestiona el estado de envío. Al confirmarse un
+  envío correcto a Mossos se debe eliminar la fila correspondiente y la lectura
+  asociada en `alpr_readings`, además de purgar imágenes vinculadas.
 
 ## Relaciones y notas
-- `cameras.certificate_id` → `certificates.id` (una cámara usa un certificado).
-- `cameras.endpoint_id` → `endpoints.id` (una cámara apunta a un endpoint).
+- `municipalities.certificate_id` → `certificates.id` (un municipio define el
+  certificado compartido por sus cámaras).
+- `municipalities.endpoint_id` → `endpoints.id` (destino por municipio; la
+  cámara puede sobrescribirlo).
+- `cameras.municipality_id` → `municipalities.id`.
+- `cameras.endpoint_id` → `endpoints.id` (si necesita un destino específico).
 - `messages_queue.reading_id` → `alpr_readings.id`.
 - Se pueden añadir índices compuestos (`plate`, `timestamp_utc`) para acelerar
   búsquedas por matrícula y rango temporal.
+
+## Posible extensión futura
+- Tabla `delivery_log` (opcional): registro de auditoría sin matrícula ni
+  imágenes, con campos como `camera_id`, `municipality_id`, `fecha_envio`,
+  `resultado` y mensajes de error resumidos para trazabilidad sin datos
+  personales.

--- a/docs/legacy-mossoswsnet.md
+++ b/docs/legacy-mossoswsnet.md
@@ -22,3 +22,12 @@ como:
 - Gestión limitada de múltiples certificados según cámara o municipio.
 - Escasa trazabilidad y herramientas de observabilidad.
 - Manejo de errores y reintentos poco configurable.
+
+## Evolución en TattileSender
+- El exe legacy mapea `SerialNumber` → `CodigoLector` mediante un único
+  `Configuration.json`, con el certificado acoplado al binario y sin un modelo
+  de municipios con múltiples certificados almacenado en base de datos.
+- TattileSender introduce tablas `municipalities`, `certificates` y `cameras`
+  para soportar de forma explícita la relación cámara → municipio → certificado
+  (y endpoint), permitiendo gestionar varios municipios y certificados de forma
+  escalable y mantenible.


### PR DESCRIPTION
## Summary
- actualizar requisitos y arquitectura para reflejar operación multi-municipio/multi-certificado y retención temporal de datos
- ampliar el esquema y modelo lógico con municipios, certificados, endpoints y ciclo de vida de lecturas y cola
- documentar diferencias con el sistema legacy y anotar modelos previstos en stubs

## Testing
- not run (documentación)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693195cf4cd8832ea4ecf5e0ea837eef)