### PR TITLE
Add setup guides for local and VPS deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,143 @@
 # TattileSender
 
-Servicio backend en Python diseñado para recibir lecturas ALPR de cámaras
-Tattile en formato XML y reenviarlas al endpoint SOAP de Mossos d'Esquadra usando
-certificados PFX específicos por cámara o municipio.
+Servicio backend en Python diseñado para recibir lecturas ALPR de cámaras Tattile en formato XML y reenviarlas al endpoint SOAP de Mossos d'Esquadra usando certificados PFX específicos por cámara o municipio.
 
-## Estado actual
-Fase 0: solo scaffolding, documentación y configuración inicial. La lógica de
-negocio (ingesta, cola, envíos SOAP) se implementará en fases posteriores.
+## Requisitos previos
+- Python 3.11 o superior.
+- PostgreSQL 15 o superior (puede ser local o vía Docker).
+- `pip` junto a `virtualenv`/`pipenv` para gestionar entornos.
+- Opcional: Docker y Docker Compose para levantar servicios rápidamente.
 
-## Tecnologías previstas
-- Python 3.11+
-- FastAPI para la API HTTP de administración
-- SQLAlchemy + Alembic sobre PostgreSQL
-- Worker/servicio de ingesta y sender en procesos Python
-- Gestión de configuración por variables de entorno y `.env`
+## Configuración del entorno (.env)
+En la raíz existe un archivo `.env.example` con las variables necesarias. Cópialo y ajústalo según tu entorno:
+
+```bash
+cp .env.example .env
+```
+
+Variables principales:
+- `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`: datos de conexión a PostgreSQL.
+- `CERTS_DIR`: ruta donde se almacenan los certificados PFX en el servidor.
+- `TRANSIT_PORT`: puerto en el que el servicio de ingesta escuchará las lecturas Tattile.
+- `APP_ENV`: entorno de ejecución (`dev`, `prod`, etc.).
+
+Valores habituales para desarrollo local:
+- `DB_HOST=localhost`
+- `DB_PORT=5432`
+- `DB_NAME=tattile_sender`
+- `DB_USER=tattile`
+- `DB_PASSWORD=changeme`
+
+## Instalación de dependencias
+1. Crear y activar el entorno virtual:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate       # Linux/macOS
+   .venv\Scripts\activate         # Windows
+   ```
+
+2. Instalar las dependencias del proyecto:
+
+   ```bash
+   pip install --upgrade pip
+   pip install -r requirements.txt
+   ```
+
+## Configurar PostgreSQL (local)
+Ejemplo básico creando usuario y base de datos que coincidan con el `.env`:
+
+```bash
+sudo -u postgres psql
+CREATE USER tattile WITH PASSWORD 'changeme';
+CREATE DATABASE tattile_sender OWNER tattile;
+GRANT ALL PRIVILEGES ON DATABASE tattile_sender TO tattile;
+```
+
+Confirma que los valores utilizados son los mismos definidos en tus variables de entorno.
+
+## Usando Docker para PostgreSQL
+El proyecto incluye un `docker-compose.yml` con un servicio `db` de PostgreSQL. Para levantar solo la base de datos:
+
+```bash
+docker compose up -d db
+```
+
+Cuando usas Docker Compose, `DB_HOST` puede ser `db` (nombre del servicio) si los procesos se ejecutan dentro de los contenedores, o `localhost` si accedes desde el host.
+
+## Migraciones de base de datos (Alembic)
+Ejecuta las migraciones antes de iniciar los servicios para crear las tablas iniciales (`municipalities`, `certificates`, `endpoints`, `cameras`, `alpr_readings`, `messages_queue`, etc.):
+
+```bash
+alembic upgrade head
+```
+
+## Lanzar la API (FastAPI)
+Arranca la API en modo desarrollo con Uvicorn:
+
+```bash
+uvicorn app.api.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Prueba el endpoint de salud:
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+La ruta `/health` devuelve el estado general, mensajes pendientes en la cola y el total de lecturas almacenadas.
+
+## Lanzar el Ingest Service
+El servicio de ingesta escucha el puerto Tattile definido en `TRANSIT_PORT`, recibe XML de lecturas, los parsea y los guarda en la base de datos.
+
+Inícialo con:
+
+```bash
+python -m app.ingest.main
+```
+
+`TRANSIT_PORT` determina el puerto de escucha. Para simular una lectura vía `netcat`:
+
+```bash
+nc 127.0.0.1 33334 << 'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <!-- XML de ejemplo aquí -->
+</root>
+EOF
+```
+
+## Probar el funcionamiento (local)
+Secuencia sugerida:
+1. Levantar PostgreSQL (local o con Docker Compose).
+2. Ejecutar `alembic upgrade head` para crear el esquema.
+3. Arrancar la API con `uvicorn app.api.main:app --reload --host 0.0.0.0 --port 8000`.
+4. Arrancar el Ingest Service con `python -m app.ingest.main`.
+5. Enviar un XML de prueba usando `nc` contra el puerto configurado.
+6. Consultar la base de datos, por ejemplo:
+   ```sql
+   SELECT * FROM alpr_readings LIMIT 5;
+   SELECT * FROM messages_queue LIMIT 5;
+   ```
+7. Llamar a `/health` para verificar `pending_messages` y `total_readings`.
+
+## Despliegue básico en un VPS Ubuntu (resumen)
+- Instalar Python 3, PostgreSQL, Git y dependencias del sistema.
+- Clonar el repositorio y crear el archivo `.env` a partir de `.env.example` con valores reales.
+- Crear el usuario y la base de datos en PostgreSQL para el proyecto.
+- Instalar dependencias con `pip install -r requirements.txt`.
+- Ejecutar las migraciones con `alembic upgrade head`.
+- Arrancar la API y el Ingest Service inicialmente desde terminal (o `tmux/screen`).
+- Configurar la cámara Tattile para enviar lecturas al puerto del VPS.
+- En fases posteriores se definirán servicios `systemd` para automatizar API e ingesta.
 
 ## Estructura del proyecto
 - `app/`: código fuente (configuración, API, servicios de ingesta y envío).
-- `docs/`: documentación funcional, técnica y de legado.
-- `legacy/`: artefactos heredados (binarios, capturas, logs) **sin** incluir
-  certificados.
+- `docs/`: documentación funcional, técnica y de despliegue.
+- `legacy/`: artefactos heredados (binarios, capturas, logs) **sin** incluir certificados.
 - `.env.example`: plantilla de variables de entorno.
-- `docker-compose.yml`: base para levantar PostgreSQL y la API en el futuro.
-
-## Puesta en marcha rápida (desarrollo)
-1. Crear y activar entorno virtual (ejemplo con `venv`):
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate
-   ```
-2. Instalar dependencias:
-   ```bash
-   pip install -r requirements.txt
-   ```
-3. Copiar `.env.example` a `.env` y ajustar valores según entorno local.
-4. (Opcional) Lanzar la API de prueba con FastAPI/uvicorn:
-   ```bash
-   uvicorn app.api.main:app --reload
-   ```
-   El endpoint `/health` responderá con el estado básico del servicio.
+- `docker-compose.yml`: base para levantar PostgreSQL y servir de referencia futura para API/ingesta.
 
 ## Notas
-- No se deben almacenar certificados `.pfx` ni contraseñas en el repositorio.
-- En producción se recomienda gestionar variables mediante el entorno del
-  sistema o servicios de secretos.
+- No se deben almacenar certificados `.pfx` ni contraseñas reales en el repositorio.
+- En producción se recomienda gestionar variables mediante el entorno del sistema o servicios de secretos.

--- a/app/api/main.py
+++ b/app/api/main.py
@@ -1,6 +1,8 @@
 """Aplicación FastAPI mínima para TattileSender.
 
-Expone un endpoint `/health` básico con métricas mínimas de la base de datos.
+Arráncala en desarrollo con `uvicorn app.api.main:app --reload` (o ajusta host
+y puerto según sea necesario). Expone un endpoint `/health` básico con métricas
+mínimas de la base de datos.
 """
 from fastapi import FastAPI
 from sqlalchemy import func

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -1,4 +1,9 @@
-"""Entry point para lanzar el servicio de ingesta."""
+"""Entry point para lanzar el servicio de ingesta.
+
+Ejecuta este módulo con `python -m app.ingest.main`; leerá el puerto de
+`TRANSIT_PORT` definido en el `.env` y pondrá a escuchar el servicio para
+recibir XML desde las cámaras Tattile.
+"""
 from app.ingest.service import run_ingest_service
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 version: "3.9"
 
+# Usa este archivo para levantar rápidamente PostgreSQL en local. La API y el
+# Ingest Service se ejecutan desde el host (entorno virtual de Python) por el
+# momento. Puedes dejar corriendo solo la base de datos con:
+#   docker compose up -d db
+
 services:
   db:
     image: postgres:15
@@ -9,31 +14,32 @@ services:
       POSTGRES_USER: ${DB_USER:-tattile}
       POSTGRES_PASSWORD: ${DB_PASSWORD:-changeme}
     ports:
-      - "5432:5432"
+      - "5432:5432"  # Expón este puerto solo si necesitas acceder desde el host
     volumes:
       - db_data:/var/lib/postgresql/data
 
-  api:
-    # Imagen base para la API; en fases futuras se añadirá un Dockerfile y el
-    # comando para ejecutar uvicorn apuntando a app.api.main:app
-    image: python:3.11-slim
-    depends_on:
-      - db
-    volumes:
-      - ./:/workspace
-    working_dir: /workspace
-    environment:
-      DB_HOST: db
-      DB_PORT: 5432
-      DB_NAME: ${DB_NAME:-tattile_sender}
-      DB_USER: ${DB_USER:-tattile}
-      DB_PASSWORD: ${DB_PASSWORD:-changeme}
-      CERTS_DIR: /certs
-      TRANSIT_PORT: ${TRANSIT_PORT:-33334}
-      APP_ENV: ${APP_ENV:-dev}
-    # command: uvicorn app.api.main:app --host 0.0.0.0 --port 8000
-    ports:
-      - "8000:8000"
+  # api:
+  #   # Ejemplo de servicio futuro para la API. Por ahora se recomienda
+  #   # ejecutarla desde el host con el entorno virtual de Python:
+  #   #   uvicorn app.api.main:app --host 0.0.0.0 --port 8000
+  #   image: python:3.11-slim
+  #   depends_on:
+  #     - db
+  #   volumes:
+  #     - ./:/workspace
+  #   working_dir: /workspace
+  #   environment:
+  #     DB_HOST: db
+  #     DB_PORT: 5432
+  #     DB_NAME: ${DB_NAME:-tattile_sender}
+  #     DB_USER: ${DB_USER:-tattile}
+  #     DB_PASSWORD: ${DB_PASSWORD:-changeme}
+  #     CERTS_DIR: /certs
+  #     TRANSIT_PORT: ${TRANSIT_PORT:-33334}
+  #     APP_ENV: ${APP_ENV:-dev}
+  #   # command: uvicorn app.api.main:app --host 0.0.0.0 --port 8000
+  #   ports:
+  #     - "8000:8000"
 
 volumes:
   db_data:

--- a/docs/deploy-vps.md
+++ b/docs/deploy-vps.md
@@ -1,0 +1,84 @@
+# Guía básica de despliegue en VPS Ubuntu
+
+Esta guía resume los pasos mínimos para desplegar TattileSender en un servidor limpio con Ubuntu 22.04. Adapta puertos, usuarios y contraseñas a tu entorno real.
+
+## Requisitos del servidor
+- Ubuntu 22.04 con acceso SSH.
+- Puertos abiertos según necesidad: 22 (SSH), 8000 para la API si se expone, 33334 (o el configurado en `TRANSIT_PORT`) para recibir lecturas Tattile.
+- Usuario con permisos de sudo.
+
+## Instalar dependencias del sistema
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y python3 python3-venv python3-pip git postgresql
+# Opcional
+sudo apt install -y docker.io docker-compose-plugin
+```
+
+## Crear usuario de sistema (opcional)
+```bash
+sudo adduser --system --group tattile
+sudo mkdir -p /opt/tattile-sender
+sudo chown tattile:tattile /opt/tattile-sender
+```
+
+## Clonar el repositorio
+```bash
+sudo -u tattile git clone https://github.com/tu-org/tattile-sender.git /opt/tattile-sender
+cd /opt/tattile-sender
+```
+
+## Configurar variables de entorno
+```bash
+cp .env.example .env
+# Edita .env para reflejar valores reales de DB, rutas de certificados y puertos.
+```
+
+## Configurar PostgreSQL en el VPS
+```bash
+sudo -u postgres psql
+CREATE USER tattile WITH PASSWORD 'cambia-esto';
+CREATE DATABASE tattile_sender OWNER tattile;
+GRANT ALL PRIVILEGES ON DATABASE tattile_sender TO tattile;
+```
+
+Si solo se aceptarán conexiones locales, asegúrate de mantener `DB_HOST=localhost` en el `.env` y de configurar adecuadamente `pg_hba.conf`.
+
+## Instalar dependencias de Python
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+## Ejecutar migraciones Alembic
+```bash
+alembic upgrade head
+```
+
+## Lanzar servicios manualmente (tmux/screen)
+En una primera fase se recomienda lanzar los procesos desde una sesión persistente:
+
+```bash
+# Ventana 1 - API
+source .venv/bin/activate
+uvicorn app.api.main:app --host 0.0.0.0 --port 8000
+
+# Ventana 2 - Ingest Service
+source .venv/bin/activate
+python -m app.ingest.main
+```
+
+Comprueba que la API responde:
+
+```bash
+curl http://127.0.0.1:8000/health
+```
+
+Verifica que el servicio de ingesta escucha el puerto definido por `TRANSIT_PORT` y que puedes enviarle XML de prueba con `nc`.
+
+## Notas de seguridad
+- Configura `ufw` u otro firewall para limitar qué IPs pueden acceder al puerto del Ingest Service.
+- No expongas innecesariamente el puerto de ingestión a internet abierto.
+- En fases posteriores se definirán unidades `systemd` para automatizar el arranque de la API y el Ingest Service.


### PR DESCRIPTION
## Summary
- expand README with detailed environment, base de datos, migraciones y pasos de ejecucion para API e ingest
- add docs/deploy-vps.md with instrucciones basicas para desplegar en un VPS Ubuntu
- clarify docker-compose usage for PostgreSQL y agregar comentarios en entrypoints de API e ingest

## Testing
- not run (documentacion y comentarios)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931991d73ec832ea23e58618ad98976)