### PR TITLE
Refactor models to SQLAlchemy 2.x typing

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -13,21 +13,13 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from sqlalchemy import (
-    Boolean,
-    Column,
-    DateTime,
-    ForeignKey,
-    Integer,
-    String,
-    Text,
-    create_engine,
-)
-from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker
 
 from app.config import settings
 
-Base = declarative_base()
+class Base(DeclarativeBase):
+    pass
 engine = create_engine(settings.database_url, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
 
@@ -35,61 +27,77 @@ SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, futu
 class Municipality(Base):
     __tablename__ = "municipalities"
 
-    id: int = Column(Integer, primary_key=True, index=True)
-    name: str = Column(String(255), nullable=False)
-    code: Optional[str] = Column(String(64), nullable=True)
-    certificate_id: Optional[int] = Column(Integer, ForeignKey("certificates.id"), nullable=True)
-    endpoint_id: Optional[int] = Column(Integer, ForeignKey("endpoints.id"), nullable=True)
-    active: bool = Column(Boolean, default=True, nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    code: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    certificate_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("certificates.id"), nullable=True
+    )
+    endpoint_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("endpoints.id"), nullable=True
+    )
+    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
 
-    certificate = relationship("Certificate", back_populates="municipalities")
-    endpoint = relationship("Endpoint", back_populates="municipalities")
-    cameras: List["Camera"] = relationship("Camera", back_populates="municipality")
+    certificate: Mapped[Optional["Certificate"]] = relationship(
+        "Certificate", back_populates="municipalities"
+    )
+    endpoint: Mapped[Optional["Endpoint"]] = relationship(
+        "Endpoint", back_populates="municipalities"
+    )
+    cameras: Mapped[List["Camera"]] = relationship("Camera", back_populates="municipality")
 
 
 class Certificate(Base):
     __tablename__ = "certificates"
 
-    id: int = Column(Integer, primary_key=True, index=True)
-    name: str = Column(String(255), nullable=False)
-    type: Optional[str] = Column(String(50), nullable=True)
-    path: Optional[str] = Column(String(1024), nullable=True)
-    password_ref: Optional[str] = Column(String(255), nullable=True)
-    valid_from: Optional[datetime] = Column(DateTime(timezone=True), nullable=True)
-    valid_to: Optional[datetime] = Column(DateTime(timezone=True), nullable=True)
-    active: bool = Column(Boolean, default=True, nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    type: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    path: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    password_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    valid_from: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    valid_to: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
 
-    municipalities: List["Municipality"] = relationship("Municipality", back_populates="certificate")
+    municipalities: Mapped[List["Municipality"]] = relationship(
+        "Municipality", back_populates="certificate"
+    )
 
 
 class Endpoint(Base):
     __tablename__ = "endpoints"
 
-    id: int = Column(Integer, primary_key=True, index=True)
-    name: str = Column(String(255), nullable=False)
-    url: str = Column(String(2048), nullable=False)
-    timeout_ms: int = Column(Integer, nullable=False, default=30000)
-    retry_max: int = Column(Integer, nullable=False, default=3)
-    retry_backoff_ms: int = Column(Integer, nullable=False, default=1000)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    url: Mapped[str] = mapped_column(String(2048), nullable=False)
+    timeout_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=30000)
+    retry_max: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    retry_backoff_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=1000)
 
-    municipalities: List["Municipality"] = relationship("Municipality", back_populates="endpoint")
-    cameras: List["Camera"] = relationship("Camera", back_populates="endpoint")
+    municipalities: Mapped[List["Municipality"]] = relationship(
+        "Municipality", back_populates="endpoint"
+    )
+    cameras: Mapped[List["Camera"]] = relationship("Camera", back_populates="endpoint")
 
 
 class Camera(Base):
     __tablename__ = "cameras"
 
-    id: int = Column(Integer, primary_key=True, index=True)
-    serial_number: str = Column(String(255), nullable=False, unique=True)
-    codigo_lector: str = Column(String(255), nullable=False)
-    description: Optional[str] = Column(String(255), nullable=True)
-    municipality_id: int = Column(Integer, ForeignKey("municipalities.id"), nullable=False)
-    endpoint_id: Optional[int] = Column(Integer, ForeignKey("endpoints.id"), nullable=True)
-    active: bool = Column(Boolean, default=True, nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    serial_number: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    codigo_lector: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    municipality_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("municipalities.id"), nullable=False
+    )
+    endpoint_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("endpoints.id"), nullable=True
+    )
+    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
 
-    municipality = relationship("Municipality", back_populates="cameras")
-    endpoint = relationship("Endpoint", back_populates="cameras")
-    readings: List["AlprReading"] = relationship("AlprReading", back_populates="camera")
+    municipality: Mapped["Municipality"] = relationship("Municipality", back_populates="cameras")
+    endpoint: Mapped[Optional["Endpoint"]] = relationship("Endpoint", back_populates="cameras")
+    readings: Mapped[List["AlprReading"]] = relationship("AlprReading", back_populates="camera")
 
 
 class AlprReading(Base):
@@ -101,29 +109,33 @@ class AlprReading(Base):
 
     __tablename__ = "alpr_readings"
 
-    id: int = Column(Integer, primary_key=True, index=True)
-    camera_id: int = Column(Integer, ForeignKey("cameras.id"), nullable=False)
-    device_sn: Optional[str] = Column(String(255), nullable=True)
-    plate: Optional[str] = Column(String(32), nullable=True)
-    timestamp_utc: Optional[datetime] = Column(DateTime(timezone=True), nullable=True)
-    direction: Optional[str] = Column(String(32), nullable=True)
-    lane_id: Optional[int] = Column(Integer, nullable=True)
-    lane_descr: Optional[str] = Column(String(255), nullable=True)
-    ocr_score: Optional[int] = Column(Integer, nullable=True)
-    country_code: Optional[str] = Column(String(16), nullable=True)
-    country: Optional[str] = Column(String(255), nullable=True)
-    bbox_min_x: Optional[int] = Column(Integer, nullable=True)
-    bbox_min_y: Optional[int] = Column(Integer, nullable=True)
-    bbox_max_x: Optional[int] = Column(Integer, nullable=True)
-    bbox_max_y: Optional[int] = Column(Integer, nullable=True)
-    char_height: Optional[int] = Column(Integer, nullable=True)
-    has_image_ocr: bool = Column(Boolean, default=False, nullable=False)
-    has_image_ctx: bool = Column(Boolean, default=False, nullable=False)
-    raw_xml: Optional[str] = Column(Text, nullable=True)
-    created_at: datetime = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    camera_id: Mapped[int] = mapped_column(Integer, ForeignKey("cameras.id"), nullable=False)
+    device_sn: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    plate: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    timestamp_utc: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    direction: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    lane_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    lane_descr: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    ocr_score: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    country_code: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
+    country: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    bbox_min_x: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    bbox_min_y: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    bbox_max_x: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    bbox_max_y: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    char_height: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    has_image_ocr: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    has_image_ctx: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    raw_xml: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
 
-    camera = relationship("Camera", back_populates="readings")
-    message = relationship("MessageQueue", back_populates="reading", uselist=False)
+    camera: Mapped["Camera"] = relationship("Camera", back_populates="readings")
+    message: Mapped[Optional["MessageQueue"]] = relationship(
+        "MessageQueue", back_populates="reading", uselist=False
+    )
 
 
 class MessageQueue(Base):
@@ -135,12 +147,14 @@ class MessageQueue(Base):
 
     __tablename__ = "messages_queue"
 
-    id: int = Column(Integer, primary_key=True, index=True)
-    reading_id: int = Column(Integer, ForeignKey("alpr_readings.id"), nullable=False)
-    status: str = Column(String(32), nullable=False, default="PENDING")
-    attempts: int = Column(Integer, nullable=False, default=0)
-    last_error: Optional[str] = Column(Text, nullable=True)
-    created_at: datetime = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False)
-    sent_at: Optional[datetime] = Column(DateTime(timezone=True), nullable=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    reading_id: Mapped[int] = mapped_column(Integer, ForeignKey("alpr_readings.id"), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="PENDING")
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+    sent_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    reading = relationship("AlprReading", back_populates="message")
+    reading: Mapped["AlprReading"] = relationship("AlprReading", back_populates="message")


### PR DESCRIPTION
## Summary
- migrate the SQLAlchemy Base to DeclarativeBase and adopt Mapped/mapped_column typing for all models
- update relationships to modern type annotations to ensure compatibility with SQLAlchemy 2.x

## Testing
- python -m alembic upgrade head --sql *(fails: environment lacks pydantic-settings dependency for BaseSettings import)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a7b911a0832e9f4dd3f0ac98a3e5)