### PR TITLE
Add UTM coordinates and PFX certificate import workflow

### DIFF
--- a/ajustes.sh
+++ b/ajustes.sh
@@ -12,7 +12,8 @@ show_add_menu() {
         echo "2) Añadir cámaras"
         echo "3) Añadir endpoints"
         echo "4) Añadir certificados"
-        echo "5) Volver al menú principal"
+        echo "5) Descomprimir certificado PFX y asignar a municipio"
+        echo "6) Volver al menú principal"
         read -rp "Seleccione una opción: " option
         case $option in
             1)
@@ -32,6 +33,10 @@ show_add_menu() {
                 read -rp "Pulsa ENTER para continuar..." _
                 ;;
             5)
+                python -m app.scripts.import_certificate_from_pfx
+                read -rp "Pulsa ENTER para continuar..." _
+                ;;
+            6)
                 break
                 ;;
             *)

--- a/alembic/versions/0003_add_utm_and_certificate_key_path.py
+++ b/alembic/versions/0003_add_utm_and_certificate_key_path.py
@@ -1,0 +1,38 @@
+"""Add UTM coords to cameras and key_path to certificates"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0003_add_utm_and_certificate_key_path"
+down_revision = "0002_sender_phase2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("cameras", sa.Column("utm_x", sa.Float(), nullable=True))
+    op.add_column("cameras", sa.Column("utm_y", sa.Float(), nullable=True))
+
+    op.add_column("certificates", sa.Column("key_path", sa.String(length=1024), nullable=True))
+    op.alter_column(
+        "certificates",
+        "type",
+        existing_type=sa.String(length=50),
+        existing_nullable=True,
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "certificates",
+        "type",
+        existing_type=sa.String(length=50),
+        existing_nullable=True,
+        server_default=None,
+    )
+    op.drop_column("certificates", "key_path")
+    op.drop_column("cameras", "utm_y")
+    op.drop_column("cameras", "utm_x")

--- a/app/models.py
+++ b/app/models.py
@@ -13,7 +13,16 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, create_engine
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    create_engine,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker
 
 from app.config import settings
@@ -52,8 +61,9 @@ class Certificate(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    type: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    type: Mapped[Optional[str]] = mapped_column(String(50), nullable=True, default="PEM_PAIR")
     path: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    key_path: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
     password_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     valid_from: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     valid_to: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -98,6 +108,13 @@ class Camera(Base):
         Integer, ForeignKey("certificates.id"), nullable=True
     )
     active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+
+    utm_x: Mapped[float | None] = mapped_column(
+        Float, nullable=True, comment="UTM31N-ETRS89 X (Este), 2 decimales"
+    )
+    utm_y: Mapped[float | None] = mapped_column(
+        Float, nullable=True, comment="UTM31N-ETRS89 Y (Norte), 2 decimales"
+    )
 
     municipality: Mapped["Municipality"] = relationship("Municipality", back_populates="cameras")
     endpoint: Mapped[Optional["Endpoint"]] = relationship("Endpoint", back_populates="cameras")

--- a/app/scripts/add_camera.py
+++ b/app/scripts/add_camera.py
@@ -57,6 +57,17 @@ def main() -> None:
     print("=== Añadir cámara ===")
     serial_number = input("Serial number (DEVICE_SN): ").strip()
     codigo_lector = input("Código lector: ").strip()
+    utm_x_str = input("Coordenada UTM X (Este, UTM31N ETRS89, 2 decimales): ").strip()
+    utm_y_str = input("Coordenada UTM Y (Norte, UTM31N ETRS89, 2 decimales): ").strip()
+
+    try:
+        utm_x = float(utm_x_str.replace(",", "."))
+        utm_y = float(utm_y_str.replace(",", "."))
+    except ValueError:
+        print(
+            "[ADD CAMERA][ERROR] Coordenadas inválidas. Deben ser números (pueden llevar coma o punto)."
+        )
+        return
 
     session = SessionLocal()
     try:
@@ -71,6 +82,8 @@ def main() -> None:
             codigo_lector=codigo_lector,
             municipality_id=municipality.id,
             endpoint_id=endpoint.id if endpoint else None,
+            utm_x=utm_x,
+            utm_y=utm_y,
             active=True,
         )
         session.add(camera)

--- a/app/scripts/import_certificate_from_pfx.py
+++ b/app/scripts/import_certificate_from_pfx.py
@@ -1,0 +1,155 @@
+"""Importa un certificado PFX y lo asigna a un municipio.
+
+Uso: python -m app.scripts.import_certificate_from_pfx
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from getpass import getpass
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models import Certificate, Municipality, SessionLocal
+
+
+def _list_municipalities(session: Session) -> list[Municipality]:
+    municipalities = session.query(Municipality).order_by(Municipality.id).all()
+    if not municipalities:
+        print("[CERT IMPORT][ERROR] No hay municipios dados de alta.")
+    else:
+        print("Municipios disponibles:")
+        for municipality in municipalities:
+            print(f"- {municipality.id}: {municipality.name}")
+    return municipalities
+
+
+def _extract_pfx_to_privpub(*, pfx_path: str, pfx_password: str, target_dir: str) -> str | None:
+    privpub_path = os.path.join(target_dir, "privpub.pem")
+    cmd = [
+        "openssl",
+        "pkcs12",
+        "-in",
+        pfx_path,
+        "-nodes",
+        "-out",
+        privpub_path,
+        "-passin",
+        f"pass:{pfx_password}",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print("[CERT IMPORT][ERROR] Fallo al ejecutar openssl pkcs12:")
+        print(result.stderr)
+        return None
+    return privpub_path
+
+
+def _split_pems(privpub_path: str, target_dir: str) -> tuple[str, str] | None:
+    key_path = os.path.join(target_dir, "key.pem")
+    cert_path = os.path.join(target_dir, "cert.pem")
+
+    with open(privpub_path, "r") as f:
+        privpub_content = f.read()
+
+    with open(key_path, "w") as f:
+        f.write(privpub_content)
+
+    blocks = privpub_content.split("-----BEGIN CERTIFICATE-----")
+    cert_blocks = [b for b in blocks if "-----END CERTIFICATE-----" in b]
+    if not cert_blocks:
+        print("[CERT IMPORT][ERROR] No se encontraron certificados en privpub.pem")
+        return None
+
+    last_cert_block = "-----BEGIN CERTIFICATE-----" + cert_blocks[-1]
+    if "-----END CERTIFICATE-----" not in last_cert_block:
+        print("[CERT IMPORT][ERROR] Último bloque de certificado está incompleto.")
+        return None
+
+    with open(cert_path, "w") as f:
+        f.write(last_cert_block)
+
+    return key_path, cert_path
+
+
+def main() -> None:
+    print("[CERT IMPORT] Importar certificado PFX y asignarlo a un municipio")
+    pfx_path = input("Ruta del fichero .pfx: ").strip()
+    cert_name = input("Nombre interno para el certificado (alias): ").strip()
+    pfx_password = getpass("Contraseña del .pfx: ")
+
+    if not os.path.isfile(pfx_path):
+        print("[CERT IMPORT][ERROR] El fichero .pfx no existe o no es accesible.")
+        return
+
+    base_certs_dir = settings.CERTS_DIR
+    os.makedirs(base_certs_dir, exist_ok=True)
+
+    slug = cert_name.lower().replace(" ", "_")
+    target_dir = os.path.join(base_certs_dir, slug)
+    os.makedirs(target_dir, exist_ok=True)
+
+    privpub_path = _extract_pfx_to_privpub(
+        pfx_path=pfx_path, pfx_password=pfx_password, target_dir=target_dir
+    )
+    if privpub_path is None:
+        return
+
+    split_result = _split_pems(privpub_path, target_dir)
+    if split_result is None:
+        return
+
+    key_path, cert_path = split_result
+    if not (os.path.isfile(key_path) and os.path.isfile(cert_path)):
+        print("[CERT IMPORT][ERROR] No se pudieron generar key.pem o cert.pem correctamente.")
+        return
+
+    session = SessionLocal()
+    try:
+        municipalities = _list_municipalities(session)
+        if not municipalities:
+            return
+
+        mun_id_str = input("ID del municipio al que asignar el certificado: ").strip()
+        try:
+            mun_id = int(mun_id_str)
+        except ValueError:
+            print("[CERT IMPORT][ERROR] ID de municipio inválido.")
+            return
+
+        municipality = session.get(Municipality, mun_id)
+        if municipality is None:
+            print("[CERT IMPORT][ERROR] Municipio no encontrado.")
+            return
+
+        rel_cert_path = os.path.join(slug, "cert.pem")
+        rel_key_path = os.path.join(slug, "key.pem")
+
+        cert = Certificate(
+            name=cert_name,
+            path=rel_cert_path,
+            key_path=rel_key_path,
+            type="PEM_PAIR",
+            active=True,
+        )
+        session.add(cert)
+        session.flush()
+
+        municipality.certificate_id = cert.id
+        session.add(municipality)
+        session.commit()
+
+        print(f"[CERT IMPORT] Certificado '{cert_name}' importado correctamente.")
+        print(f"[CERT IMPORT] Asignado al municipio '{municipality.name}' (id={municipality.id}).")
+        print(f"[CERT IMPORT] cert.pem: {cert_path}")
+        print(f"[CERT IMPORT] key.pem:  {key_path}")
+    except Exception as exc:  # noqa: BLE001
+        session.rollback()
+        print(f"[CERT IMPORT][ERROR] {exc}")
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/app/sender/mossos_client.py
+++ b/app/sender/mossos_client.py
@@ -41,7 +41,7 @@ class MossosClient:
     def __init__(
         self,
         endpoint_url: str,
-        cert_full_path: str,
+        cert_full_path: str | tuple[str, str | None],
         cert_password: Optional[str] = None,
         timeout: float = 5.0,
         verify: bool = True,
@@ -95,6 +95,12 @@ class MossosClient:
         ET.SubElement(request, ET.QName(MATRICULA_NS, "horaLectura")).text = hora_str
         ET.SubElement(request, ET.QName(MATRICULA_NS, "imgMatricula")).text = img_ocr_b64
         ET.SubElement(request, ET.QName(MATRICULA_NS, "imgContext")).text = img_ctx_b64
+
+        if camera.utm_x is not None and camera.utm_y is not None:
+            coord_x_str = f"{camera.utm_x:.2f}"
+            coord_y_str = f"{camera.utm_y:.2f}"
+            ET.SubElement(request, ET.QName(MATRICULA_NS, "coordenadaX")).text = coord_x_str
+            ET.SubElement(request, ET.QName(MATRICULA_NS, "coordenadaY")).text = coord_y_str
 
         return ET.tostring(envelope, encoding="utf-8", xml_declaration=True)
 

--- a/app/sender/worker.py
+++ b/app/sender/worker.py
@@ -133,13 +133,18 @@ def process_message(session: Session, message: MessageQueue) -> None:
 
     timeout_seconds = max((endpoint.timeout_ms or 5000) / 1000.0, 1.0)
     cert_path = _full_cert_path(certificate.path or "")
+    key_path = _full_cert_path(certificate.key_path) if certificate.key_path else None
+
     if not os.path.exists(cert_path):
         _mark_dead(session, message, f"Certificate file not found: {cert_path}")
+        return
+    if key_path and not os.path.exists(key_path):
+        _mark_dead(session, message, f"Key file not found: {key_path}")
         return
 
     client = MossosClient(
         endpoint_url=endpoint.url,
-        cert_full_path=cert_path,
+        cert_full_path=(cert_path, key_path) if key_path else cert_path,
         timeout=timeout_seconds,
     )
 


### PR DESCRIPTION
## Summary
- add UTM31N coordinate fields to cameras with migration, capture them during camera creation, and include them in Mossos SOAP requests when available
- support certificate key paths and a new PFX import script that extracts PEM files, stores them under CERTS_DIR, and assigns the certificate to a municipality via ajustes.sh
- adjust sender to consume separated cert/key pairs when available for mTLS

## Testing
- python -m compileall app


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e00c5340832e8030748ca93179a6)