### PR TITLE
Shorten Alembic revision id

### DIFF
--- a/alembic/versions/0003_add_utm_and_certificate_key_path.py
+++ b/alembic/versions/0003_add_utm_and_certificate_key_path.py
@@ -5,7 +5,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "0003_add_utm_and_certificate_key_path"
+revision = "0003_utm_cert_key"
 down_revision = "0002_sender_phase2"
 branch_labels = None
 depends_on = None

--- a/alembic/versions/0004_add_coord_and_certificate_paths.py
+++ b/alembic/versions/0004_add_coord_and_certificate_paths.py
@@ -6,7 +6,7 @@ import sqlalchemy as sa
 
 
 revision = "0004_add_coord_and_certificate_paths"
-down_revision = "0003_add_utm_and_certificate_key_path"
+down_revision = "0003_utm_cert_key"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- shorten the Alembic revision id for migration 0003 to keep it within the version_num column limit
- update migration 0004 to reference the new shorter revision id

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e65c5358832e8e90775d57d24a16)