### PR TITLE
Shorten Alembic revision identifiers

### DIFF
--- a/alembic/versions/0004_add_coord_and_certificate_paths.py
+++ b/alembic/versions/0004_add_coord_and_certificate_paths.py
@@ -5,7 +5,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "0004_add_coord_and_certificate_paths"
+revision = "0004_coord_paths"
 down_revision = "0003_utm_cert_key"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary
- shorten the long Alembic revision identifier in the latest migration to avoid truncation errors
- keep migration chain intact by preserving existing down_revision links

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e7257d50832e9198a8eaa9552b84)