### PR TITLE
Clarify Municipality-Certificate relationship

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -40,16 +40,17 @@ class Municipality(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     code: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
-    certificate_id: Mapped[Optional[int]] = mapped_column(
-        Integer, ForeignKey("certificates.id"), nullable=True
-    )
     endpoint_id: Mapped[Optional[int]] = mapped_column(
         Integer, ForeignKey("endpoints.id"), nullable=True
     )
     active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
 
     certificate: Mapped[Optional["Certificate"]] = relationship(
-        "Certificate", back_populates="municipalities", lazy="joined"
+        "Certificate",
+        back_populates="municipality",
+        foreign_keys="Certificate.municipality_id",
+        lazy="joined",
+        uselist=False,
     )
     endpoint: Mapped[Optional["Endpoint"]] = relationship(
         "Endpoint", back_populates="municipalities", lazy="joined"
@@ -70,8 +71,8 @@ class Certificate(Base):
     privpub_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     public_cert_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     password_ref: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
-    municipality_id: Mapped[int | None] = mapped_column(
-        Integer, ForeignKey("municipalities.id"), nullable=True
+    municipality_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("municipalities.id"), nullable=False
     )
     valid_from: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     valid_to: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
@@ -83,8 +84,10 @@ class Certificate(Base):
         DateTime(timezone=True), nullable=True, server_default=func.now(), onupdate=func.now()
     )
 
-    municipalities: Mapped[List["Municipality"]] = relationship(
-        "Municipality", back_populates="certificate"
+    municipality: Mapped["Municipality"] = relationship(
+        "Municipality",
+        back_populates="certificate",
+        foreign_keys=[municipality_id],
     )
     cameras: Mapped[List["Camera"]] = relationship("Camera", back_populates="certificate")
 

--- a/app/scripts/assign_municipality_certificate.py
+++ b/app/scripts/assign_municipality_certificate.py
@@ -16,7 +16,10 @@ def main() -> None:
 
         print("Municipios disponibles:")
         for m in municipalities:
-            print(f"- {m.id}: {m.name} (cert actual: {m.certificate_id})")
+            current_cert = m.certificate
+            print(
+                f"- {m.id}: {m.name} (cert actual: {current_cert.id if current_cert else 'N/A'})"
+            )
 
         muni_id = int(input("ID del municipio a actualizar: ").strip())
         municipality = session.get(Municipality, muni_id)
@@ -34,8 +37,8 @@ def main() -> None:
             print("Certificado no encontrado")
             return
 
-        municipality.certificate_id = certificate.id
-        session.add(municipality)
+        certificate.municipality_id = municipality.id
+        session.add(certificate)
         session.commit()
         print(f"Certificado {certificate.name} asignado a {municipality.name}")
     finally:

--- a/app/scripts/import_certificate_from_pfx.py
+++ b/app/scripts/import_certificate_from_pfx.py
@@ -179,15 +179,14 @@ def main() -> None:
         if municipality is None:
             return
 
-        if municipality.certificate_id:
-            existing = session.get(Certificate, municipality.certificate_id)
-            if existing:
-                answer = input(
-                    "El municipio ya tiene un certificado asignado. ¿Desea reemplazarlo? (s/N): "
-                ).strip()
-                if answer.lower() not in {"s", "si", "sí", "y", "yes"}:
-                    print("[CERT IMPORT] Operación cancelada por el usuario.")
-                    return
+        if municipality.certificate:
+            existing = municipality.certificate
+            answer = input(
+                "El municipio ya tiene un certificado asignado. ¿Desea reemplazarlo? (s/N): "
+            ).strip()
+            if answer.lower() not in {"s", "si", "sí", "y", "yes"}:
+                print("[CERT IMPORT] Operación cancelada por el usuario.")
+                return
 
         certificate = Certificate(
             alias=alias,
@@ -206,8 +205,7 @@ def main() -> None:
         session.add(certificate)
         session.flush()
 
-        municipality.certificate_id = certificate.id
-        session.add(municipality)
+        session.refresh(municipality)
         session.commit()
 
         print("[CERT IMPORT][OK] Certificado importado correctamente.")

--- a/app/scripts/update_certificate.py
+++ b/app/scripts/update_certificate.py
@@ -56,8 +56,6 @@ def main() -> None:
             certificate.name = new_alias
         if municipality:
             certificate.municipality_id = municipality.id
-            municipality.certificate_id = certificate.id
-            session.add(municipality)
 
         session.add(certificate)
         session.commit()


### PR DESCRIPTION
## Summary
- simplify Municipality/Certificate mapping to rely on a single municipality_id foreign key
- add explicit foreign_keys in relationships to avoid ambiguous joins and enforce one-to-one mapping
- update certificate assignment scripts to use the new relationship

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e82f7848832e8ed50aac344354f7)