### PR TITLE
Add detailed sender tracing logs

### DIFF
--- a/app/sender/mossos_client.py
+++ b/app/sender/mossos_client.py
@@ -10,16 +10,22 @@ from __future__ import annotations
 import base64
 import logging
 import os
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
 from xml.etree import ElementTree as ET
 
 import requests
+from lxml import etree as lxml_etree
 
 from app.models import AlprReading, Camera, Municipality
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("sender")
+logger.setLevel(logging.DEBUG)
+logger.propagate = True
+if not logger.handlers:
+    logger.addHandler(logging.NullHandler())
 
 SOAP_ENV_NS = "http://schemas.xmlsoap.org/soap/envelope/"
 MATRICULA_NS = "http://dgp.gencat.cat/matricules"
@@ -51,6 +57,22 @@ class MossosClient:
         self.cert_password = cert_password
         self.timeout = timeout
         self.verify = verify
+        self._log_init()
+
+    def _log_init(self) -> None:
+        cert_path = self.cert_full_path
+        cert_display = cert_path
+        key_display = None
+        if isinstance(cert_path, tuple):
+            cert_display, key_display = cert_path
+        logger.info("[CME] Inicializando cliente CME para endpoint=%s", self.endpoint_url)
+        logger.info("[CME] Certificado usado: %s", cert_display)
+        logger.info("[CME] Key usada: %s", key_display or "<no-key>")
+        logger.debug("[CME] Verificación SSL: %s Timeout: %s", self.verify, self.timeout)
+        if cert_display:
+            logger.debug("[CME] Cert existe: %s", os.path.exists(cert_display))
+        if key_display:
+            logger.debug("[CME] Key existe: %s", os.path.exists(key_display))
 
     def _format_date_time(self, timestamp: datetime) -> tuple[str, str]:
         ts = timestamp.astimezone(timezone.utc) if timestamp.tzinfo else timestamp.replace(tzinfo=timezone.utc)
@@ -106,6 +128,12 @@ class MossosClient:
         if coord_x_value and coord_y_value:
             ET.SubElement(request, ET.QName(MATRICULA_NS, "coordenadaX")).text = coord_x_value
             ET.SubElement(request, ET.QName(MATRICULA_NS, "coordenadaY")).text = coord_y_value
+            logger.debug(
+                "[CME] Coordenadas añadidas al SOAP X=%s Y=%s para cámara %s",
+                coord_x_value,
+                coord_y_value,
+                camera.serial_number,
+            )
         else:
             logger.warning(
                 "[SENDER][MOSSOS][WARN] Cámara %s sin coordenadas X/Y definidas",
@@ -114,20 +142,43 @@ class MossosClient:
 
         return ET.tostring(envelope, encoding="utf-8", xml_declaration=True)
 
+    def _beautify_xml(self, xml_bytes: bytes) -> str:
+        try:
+            parsed = lxml_etree.fromstring(xml_bytes)
+            return lxml_etree.tostring(parsed, pretty_print=True, encoding="unicode")
+        except Exception:
+            logger.debug("[CME] No se pudo formatear XML para logging", exc_info=True)
+            return xml_bytes.decode("utf-8", errors="replace")
+
     def send_matricula(
         self, *, reading: AlprReading, camera: Camera, municipality: Municipality
     ) -> MossosResult:
         logger.info(
-            "[SENDER][MOSSOS] Enviando lectura reading_id=%s plate=%s codiLector=%s municipio=%s",
+            "[CME] Generando SOAP para mensaje %s", reading.id
+        )
+        logger.debug(
+            "[CME] Datos mensaje id=%s plate=%s ts=%s camera=%s municipio=%s",
             reading.id,
             reading.plate,
-            camera.codigo_lector,
+            reading.timestamp_utc,
+            camera.serial_number,
             municipality.name if municipality else "?",
         )
 
         try:
             xml_payload = self._build_xml(reading=reading, camera=camera)
+            logger.info(
+                "[CME] Payload SOAP generado para lectura %s (tamaño=%s bytes)",
+                reading.id,
+                len(xml_payload),
+            )
+            logger.debug("[CME] XML Enviado:\n%s", self._beautify_xml(xml_payload))
         except Exception as exc:  # pragma: no cover - logging defensivo
+            logger.exception(
+                "[CME][ERROR] Error generando payload para lectura %s: %s",
+                reading.id,
+                exc,
+            )
             return MossosResult(success=False, code=None, error_message=str(exc), raw_response=None)
 
         headers = {
@@ -136,6 +187,7 @@ class MossosClient:
         }
 
         try:
+            send_started = time.monotonic()
             response = requests.post(
                 self.endpoint_url,
                 data=xml_payload,
@@ -144,26 +196,38 @@ class MossosClient:
                 cert=self.cert_full_path,
                 verify=self.verify,
             )
+            elapsed_ms = int((time.monotonic() - send_started) * 1000)
+            logger.info(
+                "[CME] Request SOAP completada status=%s duration_ms=%s", response.status_code, elapsed_ms
+            )
+            logger.debug(
+                "[CME] Cabeceras respuesta: %s", dict(response.headers)
+            )
             response.raise_for_status()
         except Exception as exc:  # pragma: no cover - logging defensivo
-            logger.error("[SENDER][MOSSOS][ERROR] reading_id=%s error=%s", reading.id, exc)
+            logger.exception(
+                "[CME][ERROR] Error HTTP/SSL leyendo_id=%s endpoint=%s", reading.id, self.endpoint_url
+            )
             return MossosResult(success=False, code=None, error_message=str(exc), raw_response=None)
 
         try:
             root = ET.fromstring(response.content)
         except ET.ParseError as exc:
             logger.error("[SENDER][MOSSOS][ERROR] Respuesta no parseable: %s", exc)
+            logger.debug("[CME] XML Recibido bruto:\n%s", response.text)
             return MossosResult(success=False, code=None, error_message=str(exc), raw_response=response.text)
 
         fault = root.find(".//faultstring")
         if fault is not None:
             err_msg = fault.text or "SOAP Fault"
             logger.error("[SENDER][MOSSOS][ERROR] Fault reading_id=%s error=%s", reading.id, err_msg)
+            logger.debug("[CME] XML Recibido:\n%s", self._beautify_xml(response.content))
             return MossosResult(success=False, code=None, error_message=err_msg, raw_response=response.text)
 
         resp_node = root.find(f".//{{{MATRICULA_NS}}}matriculaResponse")
         if resp_node is None:
             logger.error("[SENDER][MOSSOS][ERROR] Respuesta sin matriculaResponse")
+            logger.debug("[CME] XML Recibido:\n%s", self._beautify_xml(response.content))
             return MossosResult(success=False, code=None, error_message="Respuesta sin matriculaResponse", raw_response=response.text)
 
         code_text = resp_node.findtext(f".//{{{MATRICULA_NS}}}codiRetorn")
@@ -174,10 +238,12 @@ class MossosClient:
 
         if code_value == 1:
             logger.info("[SENDER][MOSSOS] Envío OK reading_id=%s codiRetorn=1", reading.id)
+            logger.debug("[CME] XML Recibido:\n%s", self._beautify_xml(response.content))
             return MossosResult(success=True, code=code_value, error_message=None, raw_response=response.text)
 
         error_msg = "Service not operational" if code_value == 0 else "Error en codiRetorn"
         logger.error(
             "[SENDER][MOSSOS][ERROR] reading_id=%s codiRetorn=%s", reading.id, code_value
         )
+        logger.debug("[CME] XML Recibido:\n%s", self._beautify_xml(response.content))
         return MossosResult(success=False, code=code_value, error_message=error_msg, raw_response=response.text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,7 @@ alembic>=1.12.0
 psycopg2-binary>=2.9.0
 python-dotenv>=1.0.0
 requests>=2.31.0
+# Para formateo de XML (logs legibles)
+lxml>=4.9.0
 # BaseSettings proviene de Pydantic v1; fijamos versión 1.x para compatibilidad
 pydantic>=1.10,<2.0


### PR DESCRIPTION
## Summary
- add verbose sender workflow logging covering batch lifecycle, validations, retries, and outcomes
- enhance Mossos SOAP client with structured request/response logging, certificate checks, and pretty-printed XML diagnostics
- include lxml dependency for readable XML logs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931eb0b77ac832ea97f153f88c27030)