### PR TITLE
Implement robust ALPR image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ Cuando uses Docker, `DB_HOST` puede ser `db` si ejecutas procesos en contenedore
 - Para automatizar la puesta en marcha se pueden crear unidades `systemd` que activen el entorno virtual y arranquen Uvicorn y el servicio de ingesta.
 
 ## Gestión de imágenes ALPR
-- Las cámaras pueden adjuntar imágenes base64 de matrícula (`IMAGE_OCR` → `imgMatricula`) y contexto (`IMAGE_CTX` → `imgContext`).
+- Las cámaras adjuntan imágenes base64 de matrícula (`<IMAGE_OCR>` → `imgMatricula`) y contexto (`<IMAGE_CTX>` → `imgContext`) dentro del XML.
 - El servicio de ingesta decodifica y guarda las imágenes en `IMAGES_DIR` (por defecto `data/images`), organizado por cámara y fecha: `<IMAGES_DIR>/<DEVICE_SN>/YYYY/MM/DD/<timestamp>_plate-<PLATE>_{ocr|ctx}.jpg`.
-- En la tabla `alpr_readings` se almacenan:
+- En `alpr_readings` se registran las rutas absolutas y flags:
   - `has_image_ocr` / `image_ocr_path`
   - `has_image_ctx` / `image_ctx_path`
-- El sender **solo envía** mensajes con imágenes válidas (rutas presentes en disco). Las lecturas sin imágenes o con rutas rotas se marcan como `DEAD` y no se reintentan.
+- El sender **solo envía** lecturas con imagen OCR válida y existente en disco. Si falta o no se puede leer, el mensaje pasa a `DEAD` con el motivo `NO_IMAGE_*` y no se reintenta. Si hay imagen de contexto declarada pero no accesible también se marca como `DEAD`.
 - Tras recibir `codiRetorn=1` de Mossos se eliminan la entrada en `messages_queue`, la lectura en `alpr_readings` y los ficheros de imagen asociados.
 - En despliegues productivos usa un `IMAGES_DIR` absoluto (p. ej. `/var/lib/tattilesender/images`) y garantiza permisos de escritura del usuario que ejecuta ingest y sender.

--- a/app/ingest/image_storage.py
+++ b/app/ingest/image_storage.py
@@ -1,0 +1,63 @@
+"""Helpers para guardar imágenes ALPR en disco."""
+from __future__ import annotations
+
+import base64
+import os
+from datetime import datetime
+
+from app.config import settings
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def save_reading_image_base64(
+    plate: str,
+    device_sn: str,
+    timestamp_utc: datetime,
+    kind: str,
+    base64_data: str,
+) -> str | None:
+    """Guarda una imagen ALPR (OCR o contexto) en disco.
+
+    Devuelve la ruta absoluta del fichero escrito o ``None`` si ocurre un error
+    al decodificar o persistir los bytes. Está pensada para consumir
+    directamente las etiquetas ``IMAGE_OCR`` / ``IMAGE_CTX`` del XML de Tattile.
+    """
+
+    plate_clean = (plate or "").replace(" ", "").upper()
+
+    base_dir = settings.IMAGES_DIR
+    date_part = timestamp_utc.strftime("%Y/%m/%d")
+    target_dir = os.path.join(base_dir, device_sn, date_part)
+    os.makedirs(target_dir, exist_ok=True)
+
+    ts_str = timestamp_utc.strftime("%Y%m%d%H%M%S")
+    filename = f"{ts_str}_plate-{plate_clean}_{kind}.jpg"
+    full_path = os.path.join(target_dir, filename)
+
+    try:
+        image_bytes = base64.b64decode(base64_data)
+    except Exception as e:  # pragma: no cover - logging defensivo
+        logger.error(
+            "[INGEST][IMAGE] Error decodificando base64 (%s) para %s/%s: %s",
+            kind,
+            device_sn,
+            plate_clean,
+            e,
+        )
+        return None
+
+    try:
+        with open(full_path, "wb") as f:
+            f.write(image_bytes)
+    except Exception as e:  # pragma: no cover - logging defensivo
+        logger.error(
+            "[INGEST][IMAGE] Error guardando imagen (%s) en %s: %s",
+            kind,
+            full_path,
+            e,
+        )
+        return None
+
+    return full_path

--- a/app/sender/cleanup.py
+++ b/app/sender/cleanup.py
@@ -1,0 +1,25 @@
+"""Helper para limpiar imágenes asociadas a lecturas enviadas."""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable
+
+logger = logging.getLogger("sender")
+
+
+def delete_reading_images(reading) -> None:
+    paths: Iterable[str | None] = (
+        reading.image_ocr_path if reading else None,
+        reading.image_ctx_path if reading else None,
+    )
+    for p in paths:
+        if not p:
+            continue
+        try:
+            if os.path.isfile(p):
+                os.remove(p)
+            else:
+                logger.debug("[CLEANUP] Imagen no encontrada (¿ya borrada?): %s", p)
+        except Exception as e:  # pragma: no cover - defensivo
+            logger.warning("[CLEANUP] Error al borrar imagen %s: %s", p, e)

--- a/app/sender/mossos_client.py
+++ b/app/sender/mossos_client.py
@@ -94,16 +94,18 @@ class MossosClient:
 
         data_str, hora_str = self._format_date_time(reading.timestamp_utc)
 
-        img_ocr_b64 = None
-        img_ctx_b64 = None
+        img_ctx_b64 = ""
         try:
             img_ocr_b64 = self._load_image_b64(reading.image_ocr_path, "imgMatricula")
-            img_ctx_b64 = self._load_image_b64(reading.image_ctx_path, "imgContext")
+            if reading.image_ctx_path:
+                img_ctx_b64 = self._load_image_b64(
+                    reading.image_ctx_path, "imgContext"
+                )
         except FileNotFoundError as exc:
             logger.error("[SENDER][MOSSOS][ERROR] %s", exc)
             raise
 
-        if not img_ocr_b64 or not img_ctx_b64:
+        if not img_ocr_b64:
             raise ValueError("Missing images for matriculaRequest")
 
         ET.register_namespace("soapenv", SOAP_ENV_NS)

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -76,7 +76,9 @@
   envío correcto a Mossos se debe eliminar la fila correspondiente y la lectura
   asociada en `alpr_readings`, además de purgar imágenes vinculadas.
   Los mensajes cuya lectura no tenga imágenes válidas se marcan como `DEAD` sin
-  reintentos.
+  reintentos. Errores típicos de imagen: `NO_IMAGE_AVAILABLE_OCR`,
+  `NO_IMAGE_FILE_OCR:<ruta>`, `NO_IMAGE_FILE_CTX:<ruta>`, o
+  `NO_IMAGE_FILE_RUNTIME:<detalle>`.
 
 ## Relaciones y notas
 - `municipalities.certificate_id` → `certificates.id` (un municipio define el


### PR DESCRIPTION
## Summary
- save ALPR base64 images from Tattile payloads to disk with tracked flags and absolute paths during ingest
- enforce sender-side validation for missing images, mark invalid messages as DEAD, and clean image files after successful delivery
- document the image flow and database error states for the queue

## Testing
- python -m compileall app


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f84fa0ec832e9c6561649e53bf14)