### PR TITLE
Refactoriza logging de ingest y sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,20 @@ Cuando uses Docker, `DB_HOST` puede ser `db` si ejecutas procesos en contenedore
 - El sender **solo envía** lecturas con imagen OCR válida y existente en disco. Si falta o no se puede leer, el mensaje pasa a `DEAD` con el motivo `NO_IMAGE_*` y no se reintenta. Si hay imagen de contexto declarada pero no accesible también se marca como `DEAD`.
 - Tras recibir `codiRetorn=1` de Mossos se eliminan la entrada en `messages_queue`, la lectura en `alpr_readings` y los ficheros de imagen asociados.
 - En despliegues productivos usa un `IMAGES_DIR` absoluto (p. ej. `/var/lib/tattilesender/images`) y garantiza permisos de escritura del usuario que ejecuta ingest y sender.
+
+## Logging
+- Formato de consola: "%(asctime)s [%(levelname)s] %(message)s". El nivel por defecto es `INFO`; usa `LOG_LEVEL=DEBUG` para mayor detalle.
+- Prefijos para cada componente:
+  - `[INGEST]` servicio de ingesta de XML.
+  - `[IMAGEN]` operaciones de decodificación y guardado de imágenes.
+  - `[SENDER]` worker de cola y envío.
+  - `[MOSSOS]` cliente SOAP hacia el endpoint de Mossos.
+  - `[CERT]` validación de certificados y claves.
+  - `[CLEANUP]` eliminación de imágenes tras el envío.
+- Mensajes de referencia:
+  - `[INGEST] Lectura recibida: matrícula=1234ABC, cámara=TAT001, municipio=Gava, id_lectura=10, id_mensaje=25`
+  - `[IMAGEN] Imagen OCR guardada para lectura de TAT001: /var/lib/.../ocr.jpg`
+  - `[SENDER] Envío correcto de lectura 10 (msg_id=25). Código respuesta=1`
+  - `[IMAGEN][ERROR] Error decodificando imagen ocr para cámara TAT001, matrícula=1234ABC: <detalle>`
+  - `[CERT][ERROR] Certificado no encontrado en /etc/tattilesender/certs/camara.pem`
+  - `[SENDER][DEAD] Mensaje 25 agotó reintentos y se marca DEAD: NO_IMAGE_FILE`

--- a/app/ingest/image_storage.py
+++ b/app/ingest/image_storage.py
@@ -6,9 +6,7 @@ import os
 from datetime import datetime
 
 from app.config import settings
-import logging
-
-logger = logging.getLogger(__name__)
+from app.logger import logger
 
 
 def save_reading_image_base64(
@@ -40,7 +38,7 @@ def save_reading_image_base64(
         image_bytes = base64.b64decode(base64_data)
     except Exception as e:  # pragma: no cover - logging defensivo
         logger.error(
-            "[INGEST][IMAGE] Error decodificando base64 (%s) para %s/%s: %s",
+            "[IMAGEN][ERROR] Error decodificando imagen %s para cámara %s, matrícula=%s: %s",
             kind,
             device_sn,
             plate_clean,
@@ -53,11 +51,12 @@ def save_reading_image_base64(
             f.write(image_bytes)
     except Exception as e:  # pragma: no cover - logging defensivo
         logger.error(
-            "[INGEST][IMAGE] Error guardando imagen (%s) en %s: %s",
+            "[IMAGEN][ERROR] Error guardando imagen %s en %s: %s",
             kind,
             full_path,
             e,
         )
         return None
 
+    logger.info("[IMAGEN] Imagen %s guardada para lectura de %s: %s", kind.upper(), device_sn, full_path)
     return full_path

--- a/app/ingest/main.py
+++ b/app/ingest/main.py
@@ -4,6 +4,7 @@ Ejecuta este módulo con `python -m app.ingest.main`; leerá el puerto de
 `TRANSIT_PORT` definido en el `.env` y pondrá a escuchar el servicio para
 recibir XML desde las cámaras Tattile.
 """
+from app.logger import logger  # noqa: F401 - inicializa configuración global
 from app.ingest.service import run_ingest_service
 
 

--- a/app/logger.py
+++ b/app/logger.py
@@ -1,0 +1,13 @@
+"""Configuración centralizada de logging para TattileSender."""
+from __future__ import annotations
+
+import logging
+import os
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=LOG_LEVEL,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+
+logger = logging.getLogger("tattilesender")

--- a/app/sender/cleanup.py
+++ b/app/sender/cleanup.py
@@ -1,14 +1,16 @@
 """Helper para limpiar imágenes asociadas a lecturas enviadas."""
 from __future__ import annotations
 
-import logging
 import os
 from typing import Iterable
 
-logger = logging.getLogger("sender")
+from app.logger import logger
 
 
 def delete_reading_images(reading) -> None:
+    if reading and getattr(reading, "id", None) is not None:
+        logger.info("[CLEANUP] Eliminando imágenes de lectura %s", reading.id)
+
     paths: Iterable[str | None] = (
         reading.image_ocr_path if reading else None,
         reading.image_ctx_path if reading else None,
@@ -20,6 +22,6 @@ def delete_reading_images(reading) -> None:
             if os.path.isfile(p):
                 os.remove(p)
             else:
-                logger.debug("[CLEANUP] Imagen no encontrada (¿ya borrada?): %s", p)
+                logger.info("[CLEANUP] Imagen no encontrada (ya eliminada): %s", p)
         except Exception as e:  # pragma: no cover - defensivo
             logger.warning("[CLEANUP] Error al borrar imagen %s: %s", p, e)

--- a/app/sender/main.py
+++ b/app/sender/main.py
@@ -1,16 +1,8 @@
 """Punto de entrada ejecutable para el sender worker."""
 from __future__ import annotations
 
-import logging
-import sys
-
+from app.logger import logger  # noqa: F401 - inicializa configuración global
 from app.sender.worker import run_sender_worker
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
-    stream=sys.stdout,
-)
 
 
 def main() -> None:

--- a/app/sender/mossos_client.py
+++ b/app/sender/mossos_client.py
@@ -8,7 +8,6 @@ claros y documentados sin añadir dependencias pesadas.
 from __future__ import annotations
 
 import base64
-import logging
 import os
 import time
 from dataclasses import dataclass
@@ -19,14 +18,9 @@ from xml.etree import ElementTree as ET
 import requests
 from lxml import etree as lxml_etree
 
+from app.logger import logger
 from app.models import AlprReading, Camera, Municipality
 from app.utils.images import resolve_image_path
-
-logger = logging.getLogger("sender")
-logger.setLevel(logging.DEBUG)
-logger.propagate = True
-if not logger.handlers:
-    logger.addHandler(logging.NullHandler())
 
 SOAP_ENV_NS = "http://schemas.xmlsoap.org/soap/envelope/"
 MATRICULA_NS = "http://dgp.gencat.cat/matricules"
@@ -66,14 +60,14 @@ class MossosClient:
         key_display = None
         if isinstance(cert_path, tuple):
             cert_display, key_display = cert_path
-        logger.info("[CME] Inicializando cliente CME para endpoint=%s", self.endpoint_url)
-        logger.info("[CME] Certificado usado: %s", cert_display)
-        logger.info("[CME] Key usada: %s", key_display or "<no-key>")
-        logger.debug("[CME] Verificación SSL: %s Timeout: %s", self.verify, self.timeout)
+        logger.info("[MOSSOS] Usando endpoint: %s", self.endpoint_url)
+        logger.info("[MOSSOS] Usando certificado=%s", cert_display)
+        logger.info("[CERT] Usando key=%s", key_display or "<no-key>")
+        logger.debug("[MOSSOS][DEBUG] Verificación SSL=%s Timeout=%s", self.verify, self.timeout)
         if cert_display:
-            logger.debug("[CME] Cert existe: %s", os.path.exists(cert_display))
+            logger.debug("[CERT][DEBUG] Certificado existe: %s", os.path.exists(cert_display))
         if key_display:
-            logger.debug("[CME] Key existe: %s", os.path.exists(key_display))
+            logger.debug("[CERT][DEBUG] Key existe: %s", os.path.exists(key_display))
 
     def _format_date_time(self, timestamp: datetime) -> tuple[str, str]:
         ts = timestamp.astimezone(timezone.utc) if timestamp.tzinfo else timestamp.replace(tzinfo=timezone.utc)
@@ -102,7 +96,7 @@ class MossosClient:
                     reading.image_ctx_path, "imgContext"
                 )
         except FileNotFoundError as exc:
-            logger.error("[SENDER][MOSSOS][ERROR] %s", exc)
+            logger.error("[MOSSOS][ERROR] %s", exc)
             raise
 
         if not img_ocr_b64:
@@ -133,14 +127,14 @@ class MossosClient:
             ET.SubElement(request, ET.QName(MATRICULA_NS, "coordenadaX")).text = coord_x_value
             ET.SubElement(request, ET.QName(MATRICULA_NS, "coordenadaY")).text = coord_y_value
             logger.debug(
-                "[CME] Coordenadas añadidas al SOAP X=%s Y=%s para cámara %s",
+                "[MOSSOS][DEBUG] Coordenadas añadidas al SOAP X=%s Y=%s para cámara %s",
                 coord_x_value,
                 coord_y_value,
                 camera.serial_number,
             )
         else:
             logger.warning(
-                "[SENDER][MOSSOS][WARN] Cámara %s sin coordenadas X/Y definidas",
+                "[MOSSOS][ADVERTENCIA] Cámara %s sin coordenadas X/Y definidas",
                 camera.serial_number,
             )
 
@@ -151,19 +145,20 @@ class MossosClient:
             parsed = lxml_etree.fromstring(xml_bytes)
             return lxml_etree.tostring(parsed, pretty_print=True, encoding="unicode")
         except Exception:
-            logger.debug("[CME] No se pudo formatear XML para logging", exc_info=True)
+            logger.debug("[MOSSOS][DEBUG] No se pudo formatear XML para logging", exc_info=True)
             return xml_bytes.decode("utf-8", errors="replace")
 
     def send_matricula(
         self, *, reading: AlprReading, camera: Camera, municipality: Municipality
     ) -> MossosResult:
         logger.info(
-            "[CME] Generando SOAP para mensaje %s", reading.id
-        )
-        logger.debug(
-            "[CME] Datos mensaje id=%s plate=%s ts=%s camera=%s municipio=%s",
+            "[MOSSOS] Generando SOAP para lectura %s, matrícula=%s",
             reading.id,
             reading.plate,
+        )
+        logger.debug(
+            "[MOSSOS][DEBUG] Datos lectura id=%s ts=%s cámara=%s municipio=%s",
+            reading.id,
             reading.timestamp_utc,
             camera.serial_number,
             municipality.name if municipality else "?",
@@ -172,14 +167,14 @@ class MossosClient:
         try:
             xml_payload = self._build_xml(reading=reading, camera=camera)
             logger.info(
-                "[CME] Payload SOAP generado para lectura %s (tamaño=%s bytes)",
+                "[MOSSOS] Payload SOAP generado para lectura %s (tamaño=%s bytes)",
                 reading.id,
                 len(xml_payload),
             )
-            logger.debug("[CME] XML Enviado:\n%s", self._beautify_xml(xml_payload))
+            logger.debug("[MOSSOS][DEBUG] XML Enviado:\n%s", self._beautify_xml(xml_payload))
         except Exception as exc:  # pragma: no cover - logging defensivo
             logger.exception(
-                "[CME][ERROR] Error generando payload para lectura %s: %s",
+                "[MOSSOS][ERROR] Error generando SOAP para lectura %s: %s",
                 reading.id,
                 exc,
             )
@@ -202,36 +197,40 @@ class MossosClient:
             )
             elapsed_ms = int((time.monotonic() - send_started) * 1000)
             logger.info(
-                "[CME] Request SOAP completada status=%s duration_ms=%s", response.status_code, elapsed_ms
+                "[MOSSOS] Request completada status=%s duración_ms=%s",
+                response.status_code,
+                elapsed_ms,
             )
             logger.debug(
-                "[CME] Cabeceras respuesta: %s", dict(response.headers)
+                "[MOSSOS][DEBUG] Cabeceras respuesta: %s", dict(response.headers)
             )
             response.raise_for_status()
         except Exception as exc:  # pragma: no cover - logging defensivo
             logger.exception(
-                "[CME][ERROR] Error HTTP/SSL leyendo_id=%s endpoint=%s", reading.id, self.endpoint_url
+                "[MOSSOS][ERROR] Error HTTP/SSL para lectura %s: %s",
+                reading.id,
+                exc,
             )
             return MossosResult(success=False, code=None, error_message=str(exc), raw_response=None)
 
         try:
             root = ET.fromstring(response.content)
         except ET.ParseError as exc:
-            logger.error("[SENDER][MOSSOS][ERROR] Respuesta no parseable: %s", exc)
-            logger.debug("[CME] XML Recibido bruto:\n%s", response.text)
+            logger.error("[MOSSOS][ERROR] Respuesta no parseable: %s", exc)
+            logger.debug("[MOSSOS][DEBUG] XML Recibido bruto:\n%s", response.text)
             return MossosResult(success=False, code=None, error_message=str(exc), raw_response=response.text)
 
         fault = root.find(".//faultstring")
         if fault is not None:
             err_msg = fault.text or "SOAP Fault"
-            logger.error("[SENDER][MOSSOS][ERROR] Fault reading_id=%s error=%s", reading.id, err_msg)
-            logger.debug("[CME] XML Recibido:\n%s", self._beautify_xml(response.content))
+            logger.error("[MOSSOS][ERROR] Fault reading_id=%s error=%s", reading.id, err_msg)
+            logger.debug("[MOSSOS][DEBUG] XML Recibido:\n%s", self._beautify_xml(response.content))
             return MossosResult(success=False, code=None, error_message=err_msg, raw_response=response.text)
 
         resp_node = root.find(f".//{{{MATRICULA_NS}}}matriculaResponse")
         if resp_node is None:
-            logger.error("[SENDER][MOSSOS][ERROR] Respuesta sin matriculaResponse")
-            logger.debug("[CME] XML Recibido:\n%s", self._beautify_xml(response.content))
+            logger.error("[MOSSOS][ERROR] Respuesta sin matriculaResponse")
+            logger.debug("[MOSSOS][DEBUG] XML Recibido:\n%s", self._beautify_xml(response.content))
             return MossosResult(success=False, code=None, error_message="Respuesta sin matriculaResponse", raw_response=response.text)
 
         code_text = resp_node.findtext(f".//{{{MATRICULA_NS}}}codiRetorn")
@@ -241,13 +240,13 @@ class MossosClient:
             code_value = code_text
 
         if code_value == 1:
-            logger.info("[SENDER][MOSSOS] Envío OK reading_id=%s codiRetorn=1", reading.id)
-            logger.debug("[CME] XML Recibido:\n%s", self._beautify_xml(response.content))
+            logger.info("[MOSSOS] Envío correcto reading_id=%s codiRetorn=1", reading.id)
+            logger.debug("[MOSSOS][DEBUG] XML Recibido:\n%s", self._beautify_xml(response.content))
             return MossosResult(success=True, code=code_value, error_message=None, raw_response=response.text)
 
         error_msg = "Service not operational" if code_value == 0 else "Error en codiRetorn"
         logger.error(
-            "[SENDER][MOSSOS][ERROR] reading_id=%s codiRetorn=%s", reading.id, code_value
+            "[MOSSOS][ERROR] Envío rechazado reading_id=%s codiRetorn=%s", reading.id, code_value
         )
-        logger.debug("[CME] XML Recibido:\n%s", self._beautify_xml(response.content))
+        logger.debug("[MOSSOS][DEBUG] XML Recibido:\n%s", self._beautify_xml(response.content))
         return MossosResult(success=False, code=code_value, error_message=error_msg, raw_response=response.text)

--- a/app/utils/images.py
+++ b/app/utils/images.py
@@ -2,14 +2,12 @@
 from __future__ import annotations
 
 import base64
-import logging
 import os
 from datetime import datetime, timezone
 from typing import Iterable, Optional
 
 from app.config import settings
-
-logger = logging.getLogger(__name__)
+from app.logger import logger
 
 
 def normalize_plate(plate: Optional[str]) -> str:
@@ -52,7 +50,7 @@ def save_reading_image(
     try:
         os.makedirs(target_dir, exist_ok=True)
     except OSError as exc:  # pragma: no cover - defensive
-        logger.error("No se pudo crear directorio de imágenes %s: %s", target_dir, exc)
+        logger.error("[IMAGEN][ERROR] No se pudo crear directorio de imágenes %s: %s", target_dir, exc)
         return None
 
     filename = f"{ts_str}_plate-{safe_plate}_{kind}.jpg"
@@ -61,18 +59,18 @@ def save_reading_image(
     try:
         image_bytes = base64.b64decode(base64_data)
     except Exception as exc:  # pragma: no cover - defensive
-        logger.error("No se pudo decodificar base64 de imagen %s: %s", kind, exc)
+        logger.error("[IMAGEN][ERROR] Error decodificando imagen %s: %s", kind, exc)
         return None
 
     try:
         with open(full_path, "wb") as f:
             f.write(image_bytes)
     except OSError as exc:  # pragma: no cover - filesystem
-        logger.error("No se pudo escribir la imagen %s en %s: %s", kind, full_path, exc)
+        logger.error("[IMAGEN][ERROR] No se pudo escribir la imagen %s en %s: %s", kind, full_path, exc)
         return None
 
     rel_path = os.path.relpath(full_path, settings.images_dir)
-    logger.info("[INGEST] Imagen %s almacenada en %s", kind, rel_path)
+    logger.info("[IMAGEN] Imagen %s guardada en %s", kind, rel_path)
     return rel_path
 
 


### PR DESCRIPTION
## Summary
- Centraliza la configuración de logging con un formato único y nivel configurable por entorno
- Refactoriza los logs de ingest, almacenamiento de imágenes y sender para mensajes claros en español con prefijos de dominio
- Documenta los nuevos prefijos y ejemplos de mensajes en README

## Testing
- python -m compileall app

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693289673968832e8773f04befddf16c)