### PR TITLE
Normalize image path handling for ingest and sender

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ DB_PASSWORD=cambia_est0
 CERTS_DIR=/etc/tattile_sender/certs
 
 # Directorio para almacenar imágenes ALPR decodificadas.
-IMAGES_DIR=/var/lib/tattilesender/images
+IMAGES_BASE_DIR=/data/images
 
 # Puerto en el que el servicio de ingesta recibirá las lecturas Tattile.
 TRANSIT_PORT=33334

--- a/README.md
+++ b/README.md
@@ -171,13 +171,14 @@ python -m app.admin.cli delete-camera --serial-number 2001008851
 
 ## Gestión de imágenes ALPR
 - Las cámaras adjuntan imágenes base64 de matrícula (`<IMAGE_OCR>` → `imgMatricula`) y contexto (`<IMAGE_CTX>` → `imgContext`) dentro del XML.
-- El servicio de ingesta decodifica y guarda las imágenes en `IMAGES_DIR` (por defecto `data/images`), organizado por cámara y fecha: `<IMAGES_DIR>/<DEVICE_SN>/YYYY/MM/DD/<timestamp>_plate-<PLATE>_{ocr|ctx}.jpg`.
-- En `alpr_readings` se registran las rutas absolutas y flags:
+- El directorio base de imágenes se controla con la variable `IMAGES_BASE_DIR` (o `IMAGES_DIR` por compatibilidad), recomendada en producción como `/data/images`.
+- El servicio de ingesta decodifica y guarda las imágenes de forma relativa al directorio base, organizado por cámara y fecha: `<IMAGES_BASE_DIR>/<DEVICE_SN>/YYYY/MM/DD/<timestamp>_plate-<PLATE>_{ocr|ctx}.jpg`.
+- En `alpr_readings` se almacenan **rutas relativas** respecto a `IMAGES_BASE_DIR` más los flags:
   - `has_image_ocr` / `image_ocr_path`
   - `has_image_ctx` / `image_ctx_path`
+- El sender resuelve las rutas relativas contra `IMAGES_BASE_DIR` y también admite rutas históricas que empiecen por `data/images/` para compatibilidad.
 - El sender **solo envía** lecturas con imagen OCR válida y existente en disco. Si falta o no se puede leer, el mensaje pasa a `DEAD` con el motivo `NO_IMAGE_*` y no se reintenta. Si hay imagen de contexto declarada pero no accesible también se marca como `DEAD`.
 - Tras recibir `codiRetorn=1` de Mossos se eliminan la entrada en `messages_queue`, la lectura en `alpr_readings` y los ficheros de imagen asociados.
-- En despliegues productivos usa un `IMAGES_DIR` absoluto (p. ej. `/var/lib/tattilesender/images`) y garantiza permisos de escritura del usuario que ejecuta ingest y sender.
 
 ## Logging
 - Formato de consola: "%(asctime)s [%(levelname)s] %(message)s". El nivel por defecto es `INFO`; usa `LOG_LEVEL=DEBUG` para mayor detalle.

--- a/app/config.py
+++ b/app/config.py
@@ -39,10 +39,16 @@ class Settings(BaseSettings):
     sender_default_backoff_ms: int = Field(1000, env="SENDER_DEFAULT_BACKOFF_MS")
 
     images_dir: str = Field(
-        "data/images",
-        env="IMAGES_DIR",
+        "/data/images",
+        env=("IMAGES_BASE_DIR", "IMAGES_DIR"),
         description="Directorio base para almacenar imágenes ALPR",
     )
+
+    @property
+    def images_base_dir(self) -> str:
+        """Alias explícito para el directorio base de imágenes."""
+
+        return self.images_dir
 
     @property
     def CERTS_DIR(self) -> str:

--- a/app/sender/mossos_client.py
+++ b/app/sender/mossos_client.py
@@ -74,11 +74,15 @@ class MossosClient:
         return ts.strftime("%Y-%m-%d"), ts.strftime("%H:%M:%S")
 
     def _load_image_b64(self, path: Optional[str], label: str) -> str:
-        full_path = resolve_image_path(path)
-        if not full_path:
+        if not path:
             raise FileNotFoundError(f"Ruta de imagen no disponible para {label}")
-        if not os.path.exists(full_path):
-            raise FileNotFoundError(f"No se encontró el fichero de imagen {label}: {full_path}")
+
+        full_path = resolve_image_path(path)
+        if not full_path.is_file():
+            raise FileNotFoundError(
+                f"{label}: fichero no encontrado en {full_path}"
+            )
+
         with open(full_path, "rb") as f:
             return base64.b64encode(f.read()).decode("ascii")
 

--- a/app/utils/cleanup.py
+++ b/app/utils/cleanup.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Iterable
+
+from app.utils.images import resolve_image_path
 
 logger = logging.getLogger(__name__)
 
@@ -22,12 +23,13 @@ def delete_reading_images(reading) -> int:
     for path in paths:
         if not path:
             continue
+        full_path = resolve_image_path(path)
         try:
-            if os.path.isfile(path):
-                os.remove(path)
+            if full_path.is_file():
+                full_path.unlink()
                 deleted += 1
             else:
-                logger.debug("[CLEANUP] Imagen no encontrada (¿ya borrada?): %s", path)
+                logger.debug("[CLEANUP] Imagen no encontrada (¿ya borrada?): %s", full_path)
         except Exception as exc:  # pragma: no cover - defensivo
-            logger.warning("[CLEANUP] Error al borrar imagen %s: %s", path, exc)
+            logger.warning("[CLEANUP] Error al borrar imagen %s: %s", full_path, exc)
     return deleted

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -55,7 +55,7 @@
 - `ocr_score` (numérico), `country_code` (texto), `country` (texto).
 - `bbox_min_x`, `bbox_min_y`, `bbox_max_x`, `bbox_max_y`, `char_height` (numéricos).
 - `has_image_ocr` (booleano), `has_image_ctx` (booleano): indicadores de si la lectura llegó con imágenes válidas.
-- `image_ocr_path` / `image_ctx_path` (texto, opcional): rutas (relativas a `IMAGES_DIR` o absolutas) donde se almacenaron las imágenes en disco.
+- `image_ocr_path` / `image_ctx_path` (texto, opcional): rutas relativas respecto a `IMAGES_BASE_DIR` donde se almacenaron las imágenes en disco.
 - `raw_xml` (texto largo o XML).
 - `camera_id` (uuid, fk): referencia a `cameras` para conocer municipio y
   certificados asociados.

--- a/tests/test_utils_images.py
+++ b/tests/test_utils_images.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+import app.utils.images as images
+
+
+def test_resolve_image_path_supports_relative_and_legacy(tmp_path, monkeypatch):
+    monkeypatch.setattr(images, "IMAGES_BASE", tmp_path)
+    monkeypatch.setattr(images.settings, "images_dir", str(tmp_path))
+
+    rel_path = "2001008851/2025/12/01/20251201175430_plate-ABC123_ocr.jpg"
+    legacy_path = f"data/images/{rel_path}"
+    abs_path = tmp_path / "absolute.jpg"
+    abs_path.touch()
+
+    assert images.resolve_image_path(rel_path) == tmp_path / rel_path
+    assert images.resolve_image_path(legacy_path) == tmp_path / rel_path
+    assert images.resolve_image_path(str(abs_path)) == abs_path
+
+
+def test_build_image_paths_returns_relative_and_full_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(images, "IMAGES_BASE", tmp_path)
+    monkeypatch.setattr(images.settings, "images_dir", str(tmp_path))
+
+    ts = datetime(2025, 12, 1, 17, 54, 30)
+    rel_ocr, rel_ctx, full_ocr, full_ctx = images.build_image_paths(
+        "2001008851", ts, "4225LTV"
+    )
+
+    expected_rel = "2001008851/2025/12/01/20251201175430_plate-4225LTV"
+    assert rel_ocr == f"{expected_rel}_ocr.jpg"
+    assert rel_ctx == f"{expected_rel}_ctx.jpg"
+    assert full_ocr == tmp_path / rel_ocr
+    assert full_ctx == tmp_path / rel_ctx
+    assert full_ocr.parent.exists()
+    assert full_ctx.parent.exists()


### PR DESCRIPTION
## Summary
- ensure image base directory is configurable via IMAGES_BASE_DIR/IMAGES_DIR and store paths relative to it
- update ingest and sender to build and resolve image routes safely, including legacy data/images prefixes
- document the relative-path convention and add tests for image path utilities

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69329a6fef58832e9293b96011af1618)