### PR TITLE
Fix client certificate extraction for Mossos

### DIFF
--- a/app/admin/cli.py
+++ b/app/admin/cli.py
@@ -261,11 +261,13 @@ def _execute(argv: Optional[list[str]] = None) -> int:
                 return 1
 
             print(
-                f"[CERT] PFX extraído para municipio \"{result.municipality.name}\" "
+                f"[CERT] PFX extraído y verificado para municipio \"{result.municipality.name}\" "
                 f"(id={result.municipality.id})."
             )
-            print(f"[CERT] key.pem:      {result.key_path}")
-            print(f"[CERT] privpub.pem:  {result.privpub_path}")
+            print(f"[CERT] key.pem:    {result.key_path}")
+            print(f"[CERT] client.pem: {result.client_path}")
+            if result.privpub_path:
+                print(f"[CERT] privpub.pem (bundle extra): {result.privpub_path}")
             print(f"[CERT] Certificate.id: {result.certificate.id}")
         else:
             print("Comando no reconocido")


### PR DESCRIPTION
## Summary
- extract PFX files into key.pem and client.pem (client cert plus chain), verifying the certificate matches the key
- update certificate assignment to point to client.pem/key.pem and keep privpub.pem only as an optional bundle
- refresh CLI outputs to reflect the new certificate paths and verification

## Testing
- python -m app.admin.cli --help


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932bbce0854832eaee36dd9b1c316a8)