### PR TITLE
Fix Mossos SOAP request handling and logging

### DIFF
--- a/app/ingest/service.py
+++ b/app/ingest/service.py
@@ -91,15 +91,7 @@ def process_tattile_payload(xml_str: str, session: Session) -> None:
 
         session.commit()
 
-        municipality = camera.municipality.name if camera and camera.municipality else "?"
-        logger.info(
-            "[INGEST] Lectura recibida: matrícula=%s, cámara=%s, municipio=%s, id_lectura=%s, id_mensaje=%s",
-            reading.plate,
-            device_sn,
-            municipality,
-            reading.id,
-            message.id,
-        )
+        logger.info("Lectura recibida %s de %s", reading.plate, device_sn)
     except Exception as exc:
         session.rollback()
         logger.error("[INGEST][ERROR] Error guardando lectura: %s", exc)

--- a/docs/mossos/README.md
+++ b/docs/mossos/README.md
@@ -3,44 +3,58 @@
 Este documento resume cómo preparar certificados y cómo funciona el cliente SOAP
 `matricula` incluido en TattileSender.
 
-## Certificados
+## Flujo de datos
 
-- Mossos entrega los certificados en formato `.pfx`. Es necesario convertirlos a
-  PEM (certificado + clave privada) **fuera** de la aplicación.
-- Ejemplo de conversión en un host seguro:
-  ```bash
-  openssl pkcs12 -in origen.pfx -out cert.pem -clcerts -nokeys
-  openssl pkcs12 -in origen.pfx -out key.pem -nocerts -nodes
-  cat cert.pem key.pem > mossos-combinado.pem
-  ```
-- Copia el fichero PEM resultante al directorio definido en `CERTS_DIR`.
-- Registra el certificado con `./ajustes.sh` (opción Certificados) indicando el
-  `path` relativo dentro de `CERTS_DIR`.
-- Asigna el certificado al municipio o a la cámara con los scripts de
-  asignación (`assign_municipality_certificate`, `assign_camera_certificate`).
+1. La cámara envía la lectura (XML Tattile) al servicio de ingesta.
+2. El ingest parsea y guarda la lectura en `alpr_readings` y crea una entrada en
+   `messages_queue` con estado `PENDING`.
+3. El sender procesa los mensajes pendientes, construye la petición SOAP
+   `matricula` y la envía a Mossos.
+4. Tras un `codiRetorn` satisfactorio se eliminan imágenes y registros; en caso
+   de fallo se aplican reintentos o se marca como `DEAD` según la causa.
 
-## SOAP `matricula`
+## Selección de endpoint y certificado
 
-- Espacios de nombres: `soapenv` = `http://schemas.xmlsoap.org/soap/envelope/`
-  y `mat` = `http://dgp.gencat.cat/matricules`.
-- Campos obligatorios:
-  - `codiLector`: viene de `camera.codigo_lector`.
-  - `matricula`: matrícula leída.
-  - `dataLectura` y `horaLectura`: fecha/hora UTC de la lectura.
-  - `imgMatricula` e `imgContext`: binarios en Base64.
-- La petición viaja por HTTPS usando el certificado cliente configurado. La
-  capa WS-Security no se implementa por ahora; el código deja puntos de
-  extensión (ver `app/sender/mossos_client.py`) para añadir firma XML si fuera
-  necesario.
+- **Endpoint efectivo**: el sender usa primero el endpoint de la cámara
+  (`camera.endpoint`). Si no existe, usa el endpoint del municipio. Si tampoco
+  está configurado, utiliza el endpoint global indicado en
+  `settings.MOSSOS_ENDPOINT_URL`. Si ninguno está disponible el mensaje se marca
+  como `DEAD`.
+- **Certificado WS-Security**: se usa el certificado asociado al municipio
+  (`municipality.certificate`). El cliente toma las rutas `client_cert_path`/`path`
+  y `key_path` almacenadas en la base de datos (cargadas a partir del `.pfx` del
+  municipio) para firmar la petición.
+
+## Construcción de la petición `matricula`
+
+- Se construye un diccionario de Python y se pasa a Zeep como argumentos con
+  `self.service.matricula(**payload)`.
+- Campos principales:
+  - `codiLector`: `camera.codigo_lector` (máx. 16 caracteres).
+  - `matricula`: matrícula en mayúsculas, recortada a 10 caracteres.
+  - `dataLectura`: fecha UTC de la lectura en formato `YYYY-MM-DD`.
+  - `horaLectura`: hora UTC en formato `HH:MM:SS`.
+  - `imgMatricula` e `imgContext`: binarios de las imágenes leídas en disco y
+    codificados en Base64.
+- Campos opcionales si existen datos en la lectura o cámara: `coordenadaX`,
+  `coordenadaY`, `marca`, `model`, `color`, `tipusVehicle`, `pais`.
+
+## WS-Security con Zeep
+
+- El cliente SOAP (`app/sender/mossos_client.py`) usa `zeep.wsse.signature.Signature`
+  para firmar el cuerpo del mensaje con el certificado del municipio y añadir
+  `Timestamp` y `BinarySecurityToken`.
+- Se crea el servicio con el binding `{http://dgp.gencat.cat/matricules}MatriculesSoap11`
+  apuntando al endpoint resuelto. Los logs muestran explícitamente el endpoint
+  usado al habilitar la firma.
 
 ## Política de reintentos y borrado
 
-- Los reintentos dependen del endpoint (`retry_max`, `retry_backoff_ms`) o de
-  los valores por defecto definidos en configuración.
+- Los reintentos dependen del endpoint (`retry_max`, `retry_backoff_ms`) o de los
+  valores por defecto definidos en configuración.
 - Los mensajes cuya lectura no tenga imágenes válidas (`has_image_ocr/ctx` falso,
-  rutas nulas o ficheros inexistentes) se marcan inmediatamente como `DEAD`
-  con errores `NO_IMAGE_AVAILABLE` o `NO_IMAGE_FILE` y **no** se reintentan.
-- Tras un `codiRetorn=1`:
-  - Se eliminan las imágenes en disco (si existen rutas registradas).
-  - Se borran los registros `alpr_readings` y `messages_queue` asociados.
+  rutas nulas o ficheros inexistentes) se marcan inmediatamente como `DEAD` con
+  errores `NO_IMAGE_AVAILABLE` o `NO_IMAGE_FILE` y **no** se reintentan.
+- Tras un `codiRetorn` satisfactorio (`1`/`OK`/`0000`) se eliminan las imágenes
+  en disco y los registros `alpr_readings` y `messages_queue` asociados.
 - En errores permanentes (estado `DEAD`) los datos permanecen para análisis.


### PR DESCRIPTION
## Summary
- build Mossos `matricula` payloads as dictionaries passed directly to the SOAP operation and normalize success codes
- resolve endpoints with camera/municipality/global fallbacks while using municipality certificates for WS-Security
- simplify ingest logging format and document the sender flow, request structure, and WS-Security usage

## Testing
- python -m compileall app/sender app/ingest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932d8f9a61c832ea62661fcfca8aaa4)