### PR TITLE
Fix Mossos client WS-Security signature parameters

### DIFF
--- a/app/sender/mossos_client.py
+++ b/app/sender/mossos_client.py
@@ -81,7 +81,9 @@ class MossosZeepClient:
         self.client = Client(
             wsdl=wsdl_url,
             transport=transport,
-            wsse=SignOnlySignature(keyfile=key_path, certfile=cert_path),
+            # ``Signature`` espera los argumentos ``key_file`` y ``cert_file``;
+            # usando ``keyfile``/``certfile`` Zeep lanza TypeError.
+            wsse=SignOnlySignature(key_file=key_path, cert_file=cert_path),
             settings=Settings(strict=True, xml_huge_tree=True),
         )
         self.service = self.client.create_service(BINDING_QNAME, endpoint_url)


### PR DESCRIPTION
## Summary
- use the correct zeep signature argument names when instantiating MossosZeepClient
- document why the key_file/cert_file options are required

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932dbf0ce04832eaead263acce2f531)