### PR TITLE
Fix WSSE cert parameter for zeep client

### DIFF
--- a/app/sender/mossos_client.py
+++ b/app/sender/mossos_client.py
@@ -79,7 +79,7 @@ class MossosZeepClient:
         self.client = Client(
             wsdl=wsdl_url,
             transport=transport,
-            wsse=SignOnlySignature(key_file=key_path, cert_file=cert_path),
+            wsse=SignOnlySignature(key_file=key_path, certfile=cert_path),
             settings=Settings(strict=True, xml_huge_tree=True),
         )
         self.service = self.client.create_service(BINDING_QNAME, endpoint_url)


### PR DESCRIPTION
## Summary
- update Zeep client WSSE configuration to use the correct certfile argument for BinarySignature

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932de3359b0832ebb949fc876770bef)