### PR TITLE
Simplify sender logging to focus on plates

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,12 @@ python -m app.admin.cli delete-camera --serial-number 2001008851
   - `[CERT]` validación de certificados y claves.
   - `[CLEANUP]` eliminación de imágenes tras el envío.
 - Mensajes de referencia:
-  - `[INGEST] Lectura recibida: matrícula=1234ABC, cámara=TAT001, municipio=Gava, id_lectura=10, id_mensaje=25`
-  - `[IMAGEN] Imagen OCR guardada para lectura de TAT001: /var/lib/.../ocr.jpg`
-  - `[SENDER] Envío correcto de lectura 10 (msg_id=25). Código respuesta=1`
-  - `[IMAGEN][ERROR] Error decodificando imagen ocr para cámara TAT001, matrícula=1234ABC: <detalle>`
+  - `[INGEST] Lectura recibida (6080JYH) de (2001008851)`
+  - `[SENDER] Enviando lectura (6080JYH)`
+  - `[SENDER] Reintento de lectura (6080JYH)`
+  - `[SENDER] Lectura (6080JYH) enviada correctamente a Mossos`
+  - `[SENDER][WARNING] Lectura sin imagen (4324DGM) descartada`
+  - `[SENDER][ERROR] Lectura (6080JYH) descartada por SOAP-ENV:Client: Error during certificate path validation: validity check failed`
   - `[CERT][ERROR] Certificado no encontrado en /etc/tattilesender/certs/camara.pem`
-  - `[SENDER][DEAD] Mensaje 25 agotó reintentos y se marca DEAD: NO_IMAGE_FILE`
+
+El sender prioriza ahora logs resumidos por matrícula en niveles `INFO`/`WARNING`/`ERROR`. Los detalles técnicos (ids internos, estados, tiempos) se limitan al nivel `DEBUG`.


### PR DESCRIPTION
## Summary
- streamline sender logs to focus on plate-based messages and move verbose details to debug level
- adjust image validation and error handling to emit concise warnings/errors per reading
- update logging documentation with the new sender message examples

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932e282ac44832e9f7f3796f66d8916)