### PR TITLE
Add image handling for Mossos sender

### DIFF
--- a/app/sender/mossos_client.py
+++ b/app/sender/mossos_client.py
@@ -52,7 +52,7 @@ class MossosSendResult:
     fault: Optional[str]
     raw_response: Optional[str] = None
 
-def load_image_base64(path: Optional[str]) -> bytes:
+def load_image_base64(path: Optional[str]) -> str:
     if not path:
         raise FileNotFoundError("Ruta de imagen no disponible")
 
@@ -60,7 +60,7 @@ def load_image_base64(path: Optional[str]) -> bytes:
     if not full_path.is_file():
         raise FileNotFoundError(f"Fichero no encontrado en {full_path}")
 
-    return base64.b64encode(full_path.read_bytes())
+    return base64.b64encode(full_path.read_bytes()).decode("ascii")
 
 
 class MossosZeepClient:

--- a/app/sender/worker.py
+++ b/app/sender/worker.py
@@ -192,7 +192,7 @@ def process_message(session: Session, message: MessageQueue) -> None:
 
     ok_images, image_error = _validate_images(reading)
     if not ok_images:
-        logger.warning("[SENDER] Lectura sin imagen (%s) descartada", plate)
+        logger.info("[SENDER] Lectura sin imagen (%s) descartada", plate)
         logger.debug("[SENDER][DEBUG] Motivo imagen inválida para %s: %s", plate, image_error)
         _mark_dead(
             session,
@@ -249,7 +249,7 @@ def process_message(session: Session, message: MessageQueue) -> None:
     try:
         result = client.send_matricula(reading=reading, camera=camera)
     except FileNotFoundError as exc:
-        logger.warning("[SENDER] Lectura sin imagen (%s) descartada", plate)
+        logger.info("[SENDER] Lectura sin imagen (%s) descartada", plate)
         logger.debug(
             "[IMAGEN][DEBUG] Lectura %s sin imagen por error de disco: %s", plate, exc
         )


### PR DESCRIPTION
## Summary
- ensure Mossos matricula payloads include base64-encoded plate images
- discard readings without available images while logging the expected message level

## Testing
- pytest tests/test_mossos_zeep_client.py -q *(fails: missing xmlsec dependency)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693978e1551c832e8550b0b261131af8)