### PR TITLE
Fix ingest TCP blocking that stops Tattile forwarding after startup

### DIFF
--- a/app/ingest/service.py
+++ b/app/ingest/service.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import socket
+import threading
 from typing import Callable
 
 from datetime import datetime, timezone
@@ -12,6 +13,8 @@ from app.logger import logger
 from app.ingest.image_storage import save_reading_image_base64
 from app.ingest.parser import TattileParseError, parse_tattile_xml
 from app.models import AlprReading, Camera, MessageQueue, SessionLocal
+
+READ_TIMEOUT_SECONDS = 1.0
 
 
 def process_tattile_payload(xml_str: str, session: Session) -> None:
@@ -102,20 +105,45 @@ def process_tattile_payload(xml_str: str, session: Session) -> None:
         raise
 
 
-def _serve_connection(conn: socket.socket, addr: tuple, session_factory: Callable[[], Session]) -> None:
+def _read_connection_payload(conn: socket.socket, addr: tuple) -> str:
+    """Lee el payload XML completo o hasta timeout de inactividad.
+
+    Algunas cámaras mantienen la conexión TCP abierta tras enviar un mensaje.
+    Para evitar bloquear el servicio, se corta la lectura tras un periodo breve
+    sin datos una vez recibido al menos un chunk.
+    """
+
     data_chunks: list[bytes] = []
+    conn.settimeout(READ_TIMEOUT_SECONDS)
     with conn:
         while True:
-            chunk = conn.recv(4096)
+            try:
+                chunk = conn.recv(4096)
+            except socket.timeout:
+                if data_chunks:
+                    logger.debug(
+                        "[INGEST] Timeout leyendo %s tras recibir datos; se procesa payload parcial",
+                        addr,
+                    )
+                    break
+                logger.debug("[INGEST] Timeout leyendo %s sin datos; se cierra conexión", addr)
+                return ""
             if not chunk:
                 break
             data_chunks.append(chunk)
 
     if not data_chunks:
         logger.debug("Conexión %s cerrada sin datos", addr)
+        return ""
+
+    return b"".join(data_chunks).decode("utf-8", errors="replace")
+
+
+def _serve_connection(conn: socket.socket, addr: tuple, session_factory: Callable[[], Session]) -> None:
+    xml_str = _read_connection_payload(conn, addr)
+    if not xml_str:
         return
 
-    xml_str = b"".join(data_chunks).decode("utf-8", errors="replace")
     session = session_factory()
     try:
         process_tattile_payload(xml_str, session)
@@ -142,4 +170,9 @@ def run_ingest_service() -> None:
         while True:
             conn, addr = server_socket.accept()
             logger.debug("[INGEST] Conexión entrante desde %s", addr)
-            _serve_connection(conn, addr, SessionLocal)
+            worker = threading.Thread(
+                target=_serve_connection,
+                args=(conn, addr, SessionLocal),
+                daemon=True,
+            )
+            worker.start()

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -1,0 +1,29 @@
+import socket
+
+from app.ingest import service
+
+
+def test_read_connection_payload_returns_data_on_inactivity_timeout(monkeypatch):
+    monkeypatch.setattr(service, "READ_TIMEOUT_SECONDS", 0.05)
+
+    server_sock, client_sock = socket.socketpair()
+    try:
+        client_sock.sendall(b"<MESSAGE><PLATE_STRING>1234ABC</PLATE_STRING></MESSAGE>")
+        payload = service._read_connection_payload(server_sock, ("127.0.0.1", 12345))
+    finally:
+        client_sock.close()
+
+    assert payload.startswith("<MESSAGE>")
+    assert payload.endswith("</MESSAGE>")
+
+
+def test_read_connection_payload_empty_when_no_data(monkeypatch):
+    monkeypatch.setattr(service, "READ_TIMEOUT_SECONDS", 0.05)
+
+    server_sock, client_sock = socket.socketpair()
+    try:
+        payload = service._read_connection_payload(server_sock, ("127.0.0.1", 12345))
+    finally:
+        client_sock.close()
+
+    assert payload == ""


### PR DESCRIPTION
### Motivation
- El servicio TCP de ingesta leía hasta EOF y quedaba bloqueado si una cámara mantenía la conexión abierta, lo que impedía aceptar nuevas lecturas Tattile y provocaba que las inserciones se detuvieran tras el reinicio.
- Lector Vision seguía funcionando porque entra por HTTP y no usa el loop TCP bloqueante, lo que explicó la diferencia de comportamiento observado.
- Se necesitaba un comportamiento robusto para procesar payloads aunque el cliente no cierre la conexión y evitar que una conexión lenta bloquee todo el servicio.

### Description
- Añadido `READ_TIMEOUT_SECONDS` y una nueva función `_read_connection_payload` que aplica un timeout de inactividad y devuelve el payload recibido hasta ese momento en lugar de bloquear hasta EOF (archivo modificado: `app/ingest/service.py`).
- Refactorizado el flujo de lectura de socket para usar `_read_connection_payload` y retornar una cadena vacía cuando no hay datos, evitando intentos de procesado inválidos (archivo modificado: `app/ingest/service.py`).
- El loop de `accept()` ahora lanza un hilo daemon por conexión que ejecuta `_serve_connection`, de modo que una conexión lenta o mantenida no impida aceptar nuevas conexiones (archivo modificado: `app/ingest/service.py`).
- Añadido un test nuevo `tests/test_ingest_service.py` que valida la lectura por timeout tanto cuando llegan datos como cuando no llegan, y que cubre el nuevo comportamiento.

### Testing
- Ejecutado `pytest -q tests/test_ingest_service.py tests/test_ingest_integration.py tests/test_lectorvision.py` y todos los tests automáticos pasaron: `8 passed`.
- Las pruebas nuevas confirmaron que `_read_connection_payload` devuelve el XML cuando el cliente envía datos y mantiene la conexión, y devuelve cadena vacía si no hay datos antes del timeout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aab7d9ff1c832eb84d7dd57a1f9704)